### PR TITLE
Option -f, startup times reduced

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -240,14 +240,19 @@ _files_versions() {
 # DETERMINE TYPE, SIZE AND DATABASE
 
 _files_if_appimage() {
-	echo " ◆ $arg	|	appimage" >> "$AMCACHEDIR"/files-type
-	if [ ! -x ./"$arg/$arg" ]; then
-		if command -v aisap >/dev/null 2>&1 \
-		|| command -v sas >/dev/null 2>&1; then
-			sed -i "/ ◆ $arg	/s/$/🔒/" "$AMCACHEDIR"/files-type
+	if ! head -c1000000 ./"$arg/$arg" 2>/dev/null | grep -qa 'AppImages require FUSE to run'; then
+		if head -c1000 "$FILE" 2>/dev/null | grep -q "SANDBOXCMD"; then
+			echo " ◆ $arg	|	appimage🔒" >> "$AMCACHEDIR"/files-type
+		else
+			echo " ◆ $arg	|	appimage" >> "$AMCACHEDIR"/files-type
+		fi
+	else
+		if head -c1000 "$FILE" 2>/dev/null | grep -q "SANDBOXCMD"; then
+			echo " ◆ $arg	|	appimage🔒*" >> "$AMCACHEDIR"/files-type
+		else
+			echo " ◆ $arg	|	appimage*" >> "$AMCACHEDIR"/files-type
 		fi
 	fi
-	grep -Eaoq -m 1 'AppImages require FUSE to run' ./"$arg/$arg" && sed -i "/ ◆ $arg	/s/$/\*/" "$AMCACHEDIR"/files-type
 }
 
 _files_if_binary() {
@@ -363,6 +368,7 @@ _files() {
 			[ -f ./"$arg"/AM-LOCK ] && APPVERSION="$APPVERSION🔒"
 			echo "$APPVERSION" | grep -q "🔒$" && APPLOCKED=1
 			APPTYPE=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-type | uniq | awk '{print $4}')
+			[ -z "$APPTYPE" ] && _files_type && APPTYPE=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-type | uniq | awk '{print $4}')
 			APPSYZE=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-sizes | uniq | awk '{print $4}')
 			APPDB=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-db | uniq | awk '{print $4}')
 			if [ -f "$AMCACHEDIR"/files-db ] && grep -q "unsupported\|$third_party_lists_find" "$AMCACHEDIR"/files-db; then


### PR DESCRIPTION
fix https://github.com/ivan-hc/AM/issues/1777

I reused the old `_files_if_appimage` function, but this time using `head -c10` to scan the executable, with `grep` following to read the output.

This `am -f` command is 10 times faster at first run, and 1/10 faster all other times.

In the screenshots, the first test is performed after the system reboot. 

| Before |  After |
| - | - |
| <img width="747" height="564" alt="Istantanea_2025-08-20_01-17-05" src="https://github.com/user-attachments/assets/6992ff1c-9de1-4209-b044-3d5a8a4e7f60" /> | <img width="747" height="564" alt="Istantanea_2025-08-20_02-37-44" src="https://github.com/user-attachments/assets/7a134270-51e0-44c8-aefa-b4589c51a742" /> |

The programs tested are the following:

<img width="747" height="888" alt="Istantanea_2025-08-20_01-44-28" src="https://github.com/user-attachments/assets/3f4f3a3b-ddc9-4fdd-9813-c792f6ee2b0b" />
