### PR TITLE
add rog ally builds to `eden-nightly`

### DIFF
--- a/programs/x86_64/eden-nightly
+++ b/programs/x86_64/eden-nightly
@@ -17,18 +17,18 @@ read -r -p "
 
  1) Common
  2) Steamdeck
- 3) Any
+ 3) ROG Ally
+ 4) Any
 
  Which version you choose (type a number and press ENTER)?" response
 RELEASE=""
-if echo "$response" | grep -q "^1"; then
-	RELEASE="Common"
-elif echo "$response" | grep -q "^2"; then
-	RELEASE="Steamdeck"
-elif echo "$response" | grep -q "^3"; then
-	RELEASE="$APP"
-fi
-[ -z "$RELEASE" ] && exit 0
+case "$response" in
+	1) RELEASE="Common";;
+	2) RELEASE="Steamdeck";;
+	3) RELEASE="ROG";;
+	4) RELEASE="$APP";;
+esac
+[ -z "$RELEASE" ] && exit 1
 
 version=$(curl -Ls https://api.github.com/repos/pflyly/eden-nightly/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*x86_64.*mage$" | grep -i "$RELEASE" | grep -vi light | head -1)
 if [ -z "$version" ]; then


### PR DESCRIPTION
also changed the if statements for a single case statement. 

Also when `RELEASE` is empty the script should exit with error instead of `exit 0`