### PR TITLE
Clone and convert x86_64 scripts to aarch64 (if URL exists)

### DIFF
--- a/modules/template.am
+++ b/modules/template.am
@@ -217,6 +217,18 @@ _template_test_github_url() {
 	echo "$GHURLPREVIEW"
 }
 
+_template_test_github_arm64_url() {
+	if [ "$ARCH" = x86_64 ] && grep -q "^version=.*api.github.com" ./am-scripts/"$ARCH"/"$arg"; then
+		GHURLPREVIEW_COMMAND_ARM64=$(echo "$GHURLPREVIEW_COMMAND" | sed -- "s#grep -vi .*armv7l\"# grep -i \"aarch64\\\|arm64\"#g")
+		GHURLPREVIEW_ARM64=$(eval "$GHURLPREVIEW_COMMAND_ARM64")
+		if [ -n "$GHURLPREVIEW_ARM64" ]; then
+			mkdir -p ./am-scripts/aarch64
+			cp -r ./am-scripts/"$ARCH"/"$arg" ./am-scripts/aarch64/"$arg"
+			sed -i -- "s#grep -vi .*armv7l\"# grep -i \"aarch64\\\|arm64\"#g" ./am-scripts/aarch64/"$arg"
+		fi
+	fi
+}
+
 _template_then_git_repo() {
 	_template_if_git_repo
 	# Set the release as "latest" or keep it generic
@@ -378,6 +390,7 @@ for arg in $ARGS; do
 					_template_help_by_repology
 				fi
 			esac
+			_template_test_github_arm64_url
 			# END OF THIS FUNCTION
 			echo "$DIVIDING_LINE"
 			echo -e $"\n All files are saved in $SCRIPTDIR/am-scripts\n"
@@ -451,6 +464,7 @@ for arg in $ARGS; do
 			else
 				echo "$DIVIDING_LINE"
 			fi
+			_template_test_github_arm64_url
 			# END OF THIS FUNCTION
 			echo -e $"\n All files are saved in $SCRIPTDIR/am-scripts\n"
 			;;


### PR DESCRIPTION
@Samueru-sama @fiftydinar @Shikakiben

Since you create scripts for aarch64, this solution will clone your created x86_64 scripts to create an aarch64 one.


https://github.com/user-attachments/assets/7722ee8d-1d8c-4e80-8924-8a0c8cb72a48

If you have other suggestion, let me know.

This works for AppImages and portable apps on github.com

EDIT: obviously, if the aarch64 URL does not exists, no script will be cloned and converted.