### PR TITLE
Update install.am - add integrity check for broken download URLs

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -271,6 +271,24 @@ _ending_the_installation() {
 	fi
 }
 
+_install_script_retry() {
+	# Determine if the installation has stopped when trying to download the app
+	test_lastdir=$(ls -td "$APPSPATH"/* | head -1 | sed 's:.*/::')
+	test_lastdir_tmp="$APPSPATH/$test_lastdir/tmp"
+	printf " \n Oops! Something went wrong! Integrity check in progress... \n"
+	TAKES_COUNT=0
+	while [ "$TAKES_COUNT" -lt 5 ]; do
+		if [ -d "$test_lastdir_tmp" ]; then
+			if [ -z "$( ls -A "$test_lastdir_tmp" )" ]; then
+				printf "\n The file was not downloaded, attempt %b of 5 will start in 5 seconds...\n\n" "$((TAKES_COUNT + 1))"
+				sleep 5
+				$SUDOCMD ./"$arg"
+			fi
+		fi
+		TAKES_COUNT=$((TAKES_COUNT + 1))
+	done
+}
+
 _install_arg() {
 	# This function is needed to parse the installation script and then execute it
 	APPNAME=$(echo "\"$pure_arg\"" | tr '[:lower:]' '[:upper:]')
@@ -288,7 +306,7 @@ _install_arg() {
 		fi
 	fi
 	# Install script
-	$SUDOCMD ./"$arg"
+	$SUDOCMD ./"$arg" || _install_script_retry
 	echo ""
 	_post_installation_processes
 	_ending_the_installation


### PR DESCRIPTION
The installation scripts include an `exit 1` that is executed if a URL download (via `wget`) fails.

This error is often due to temporary connection drops.

This change checks whether the "tmp" directory created during installation still exists, and if so, checks whether it is empty. If it is empty, up to 5 download attempts will be made, spaced 5 seconds apart.

In this example, I'm testing an installation script from a repository where the "latest" release doesn't exist, but only pre-releases, https://github.com/niess/python-appimage

During the process, I'll modify the running script (they run in ~/.cache/appman or ~/.cache/am, in my case I use `am -i --user`, so its a local installation, like AppMan) so that it will search for, find, and install the first generic release it finds.

https://github.com/user-attachments/assets/a61fb6a2-842b-4faf-a76f-acdb258fc46f

This will also help me with false positives in https://github.com/ivan-hc/amcheck