### PR TITLE
Option "-l", in third-party databases, only counts commands

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -529,7 +529,7 @@ _list() {
 	for t in $tp_lists; do
 		[ -z "$TP_LISTS" ] && TP_LISTS=$(sort -u "$t") || TP_LISTS="$TP_LISTS\n$(sort -u "$t")"
 	done
-	[ -n "$third_party_lists" ] && AVAILABLE_THIRD_PARTY_NUMBER=$(printf "%b" "$TP_LISTS" | sort -u | grep -e "^◆.*$" -c)
+	[ -n "$third_party_lists" ] && AVAILABLE_THIRD_PARTY_NUMBER=$(printf "%b" "$TP_LISTS" | grep -Eo "^◆ .* : " | sort -u | grep -e "^◆.*$" -c)
 	[ -n "$AVAILABLE_THIRD_PARTY_NUMBER" ] && AVAILABLE_TOTAL_APPS_NUMBER=$(("$AVAILABLE_APPS_NUMBER" + "$AVAILABLE_THIRD_PARTY_NUMBER")) || AVAILABLE_TOTAL_APPS_NUMBER="$AVAILABLE_APPS_NUMBER"
 	# Generate a list of the installed apps with version
 	[ ! -f "$AMCACHEDIR"/version-args ] && _check_version
@@ -659,7 +659,7 @@ case "$1" in
 				wget -q --tries=10 --timeout=20 --spider https://github.com && _sync_third_party_lists 2>/dev/null
 				_list
 				tplist_name=$(echo "$2" | tr '-' '\n ' | grep .)
-				[ -f "$AMDATADIR"/"$ARCH"-"$tplist_name" ] && TPNUMBER_HERE=$(sort -u "$AMDATADIR"/"$ARCH"-"$tplist_name" | wc -l)
+				[ -f "$AMDATADIR"/"$ARCH"-"$tplist_name" ] && TPNUMBER_HERE=$(sort -u "$AMDATADIR"/"$ARCH"-"$tplist_name" | grep -Eo "^◆ .* : " | uniq | wc -l)
 				SUBJECT=$(echo $"$TPNUMBER_HERE programs available in the ${tplist_name^} database")
 				LIST=$(sort -u "$AMDATADIR"/"$ARCH"-"$tplist_name" | grep "^◆ .*$" 2>/dev/null | _pretty_list)
 				_list_msg "$@" | less -Ir


### PR DESCRIPTION
Previously, third-party databases considered the total number of packages (unlike the AM database, which only counts unique packages).

From now on, the total number of commands will appear, while the lists will continue to list variants of the same command.

| Before | After |
| - | - |
| <img width="747" height="582" alt="before" src="https://github.com/user-attachments/assets/02db58cd-100c-40e9-8291-b2ab440ea753" /> | <img width="747" height="582" alt="after" src="https://github.com/user-attachments/assets/28ed9a3d-37d4-42e8-bf50-414f759c913c" /> |
