### PR TITLE
fix: update session-desktop repo from oxen-io to session-foundation

### DIFF
--- a/programs/x86_64/session-desktop
+++ b/programs/x86_64/session-desktop
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=session-desktop
-SITE="oxen-io/session-desktop"
+SITE="session-foundation/session-desktop"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/oxen-io/session-desktop/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/session-foundation/session-desktop/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -31,9 +31,9 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=session-desktop
-SITE="oxen-io/session-desktop"
+SITE="session-foundation/session-desktop"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/oxen-io/session-desktop/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/session-foundation/session-desktop/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1


### PR DESCRIPTION
The oxen-io/session-desktop repo has been archived and moved to session-foundation/session-desktop. This is documented on the oxen-io/session-desktop repo