### PR TITLE
Option -f, remove subshell

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -326,7 +326,7 @@ _files_files() {
 	_check_version
 	rm -f "$AMCACHEDIR"/files-*
 	for arg in $INSTALLED_APPS; do
-		[ -f ./"$arg"/remove ] && _files_db && _files_sizes && _files_type &
+		[ -f ./"$arg"/remove ] && _files_db && _files_sizes && _files_type
 	done
 }
 
@@ -336,8 +336,7 @@ _files() {
 	INSTALLED_APPS_BY_SIZE=$(du -sh $INSTALLED_APPS_PATHS 2>/dev/null | sort -rh)
 	INSTALLED_APPS=$(echo "$INSTALLED_APPS_BY_SIZE" | grep "$APPSPATH" | sed 's:.*/::' | xargs)
 
-	sh -c "$(_files_files)"
-	wait
+	_files_files
 	rm -f "$AMCACHEDIR"/files-args
 	for arg in $INSTALLED_APPS; do
 		if test -f ./"$arg"/remove 2>/dev/null; then


### PR DESCRIPTION
- PROS: Prevents unintentional program launches when testing variables (in function "_determine_args")
- CONS: 20 milliseconds slower (on AMD Ryzen 5)