### PR TITLE
Fix missing version in AM where apps are installed in multiple levels

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.9.1-4"
+AMVERSION="9.9.1-5"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -794,7 +794,7 @@ _check_version() {
 	_determine_args
 	for arg in $ARGS; do
 		(
-		argpath=$(echo "$ARGPATHS" | grep "/$arg$")
+		argpath=$(echo "$ARGPATHS" | tr ' ' '\n' | grep "^$APPSPATH.*/$arg$")
 		if [ -f "$argpath"/remove ]; then
 			if [ -f "$argpath"/version ]; then
 				_check_version_if_version_file_exists
@@ -812,7 +812,9 @@ _check_version() {
 			if [ -z "$APPVERSION" ]; then
 				[ -f "$argpath"/"$arg" ] && _check_version_if_binary_in_place || APPVERSION="unknown"
 			fi
-			echo " ◆ $arg	|	$APPVERSION" >> "$AMCACHEDIR"/version-args
+			if ! grep -q " ◆ $arg	|" "$AMCACHEDIR"/version-args 2>/dev/null; then
+				echo " ◆ $arg	|	$APPVERSION" >> "$AMCACHEDIR"/version-args
+			fi
 		fi
 		) &
 	done


### PR DESCRIPTION
fix https://github.com/ivan-hc/AM/issues/1989

In the example below, `nvim` is installed both system-wide and locally

| BEFORE | AFTER |
| - | - |
| <img width="747" height="834" alt="Istantanea_2025-12-26_16-55-48" src="https://github.com/user-attachments/assets/1a61b5e1-2883-4a72-a2d1-3b1b0b15967a" /> | <img width="747" height="834" alt="Istantanea_2025-12-26_16-56-13" src="https://github.com/user-attachments/assets/30f2228b-88f9-4ea8-97fd-c971c13b1d79" /> |

NOTE: I suggest avoiding installing the same app in more than one permission level.