### PR TITLE
Add support for Hildon launcher desktop path used in Maemo

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -200,7 +200,7 @@ _apply_patches() {
 	if [ "$AMCLI" = "appman" ]; then
 		sed -i "s#/usr/local/bin#$BINDIR#g" ./"$arg"
 		if command -v hildon-home 1>/dev/null; then
-			sed -i "s#/usr/local/share/applications#$DATADIR/share/applications/hildon#g" ./"$arg"
+			sed -i "s#/usr/local/share/applications#$DATADIR/applications/hildon#g" ./"$arg"
 		fi
 		sed -i "s#/usr/local/share#$DATADIR#g" ./"$arg"
 		sed -i "s#/opt/#$APPSPATH/#g" ./"$arg"


### PR DESCRIPTION
It's in non-standard `$DATADIR/applications/hildon/` instead in `$DATADIR/applications/`

Closes: https://github.com/ivan-hc/AM/issues/2008