### PR TITLE
Option -t, warn the user that an appname already exists

### DIFF
--- a/modules/template.am
+++ b/modules/template.am
@@ -423,7 +423,7 @@ case $2 in
 	;;
 esac
 
-[ ! -f "$AMDATADIR"/"$ARCH"-apps ] && _completion_lists
+[ -f "$AMDATADIR"/"$ARCH"-apps ] || _completion_lists
 
 ARGS="$(echo "$@" | cut -f2- -d ' ')"
 for arg in $ARGS; do


### PR DESCRIPTION
If that name already exists, you can only proceed by pressing Y, otherwise it moves on to the next appname.