### PR TITLE
Added support for checksum verification in install scripts.

### DIFF
--- a/modules/template.am
+++ b/modules/template.am
@@ -342,6 +342,22 @@ _template_then_git_repo() {
 	esac
 }
 
+_template_verify_checksum() {
+	echo "$DIVIDING_LINE"
+	read -r -p $" Verify appimage checksum integrity? (sha1sum, sha256sum, sha512sum, md5sum, none)? " chksumtool
+	case "$chksumtool" in
+	'sha1sum'|'sha256sum'|'sha512sum'|'md5sum')
+		echo "$DIVIDING_LINE"
+		read -r -p $" Provide checksum URL (eg. \$version.zsync or download page): " chksumlink
+		sed -i "s/CHKSUM_TOOL/$chksumtool/g" ./am-scripts/"$MAIN_ARCH"/"$arg"
+		sed -i "s/CHKSUM_URL/$chksumlink/g" ./am-scripts/"$MAIN_ARCH"/"$arg"
+		;;
+	*)
+		sed -i "/checksum/d" ./am-scripts/"$MAIN_ARCH"/"$arg"
+		;;
+	esac
+}
+
 # ------------------------------------------------------------------------
 # FUNCTIONS SPECIFIC PER WEBSITE
 # ------------------------------------------------------------------------
@@ -483,6 +499,7 @@ for arg in $ARGS; do
 				fi
 			esac
 			_template_test_github_alt_architectures_url
+			_template_verify_checksum
 			# END OF THIS FUNCTION
 			echo "$DIVIDING_LINE"
 			echo -e $"\n All files are saved in $SCRIPTDIR/am-scripts\n"

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -22,6 +22,9 @@ mv ./tmp/*mage ./"$APP"
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
 chmod a+x ./"$APP" || exit 1
+checksum=`CHKSUM_TOOL ./"$APP" | awk '{ print $1 }'`
+results=`curl -Ls "CHKSUM_URL" | grep -a $checksum`
+[ "$results" = "" ] && echo "Warning: Appimage checksum verification failed, please manually verify file integrity"
 
 # LINK TO PATH
 ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
@@ -48,6 +51,9 @@ if [ "$version" != "$version0" ]; then
 	mv --backup=t ./tmp/*mage ./"$APP"
 	chmod a+x ./"$APP" || exit 1
 	echo "$version" > ./version
+	checksum=`CHKSUM_TOOL ./"$APP" | awk '{ print $1 }'`
+	results=`curl -Ls "CHKSUM_URL" | grep -a $checksum`
+	[ "$results" = "" ] && echo "Warning: Appimage checksum verification failed, please manually verify file integrity"
 	rm -R -f ./*zs-old ./*.part ./tmp ./*~
 	notify-send "$APP is updated!"
 else


### PR DESCRIPTION
Added initial work for checksum verification support in template.am, based on our discussion in #2104.

Tested with pkgforge-dev/mednafen-appimage with checksum URL = $version.zsync. It should also work for download pages that publish the checksum directly on the page.

Maintainers can slowly enable checksum verification as they see fit, else they can just select "none". Checksum verification failure will only show a warning, prompting users to manually verify the binary. It will not break the installation flow.