### PR TITLE
Added _use_verify() function into APP-MANAGER for checksum verification

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1414,15 +1414,13 @@ _use_verify() {
 			printf "Source is tarball/zip" > "$argpath"/AM-VERIFIED
 			return 1
 		# Search for hash files
-		elif [ -f "$argpath"/version ] && [ ! -z $(grep -a "^http" "$argpath"/version) ]; then
+		elif [ -f "$argpath"/version ] && [ ! -z "$(grep -a "^http" "$argpath"/version)" ]; then
 			# Search for zsync file
 			digest=$(curl -Ls "$(sort "$argpath/version").zsync" | grep -a "SHA\|MD5")
 			# Search for DIGEST file if no zsync file
 			if [ -z "$digest" ]; then
 				digest=$(curl -Ls "$(sort "$argpath/version").DIGEST")
-				results=$(echo "$digest" | grep -ia "not found")
-				# TODO: Refactor this
-				if [ ! -z "$results" ]; then
+				if [ ! -z "$(echo "$digest" | grep -ia "not found")" ]; then
 					printf $" %b⚠️\033[0m Checksum for %b cannot be automatically verified, no hashes found \n" "${Gold}" "$(echo "$arg" | tr '[:lower:]' '[:upper:]')"
 					return 1
 				fi
@@ -1454,7 +1452,7 @@ _use_verify() {
 		[ -z "$checksum_tools_on" ] && echo "Checksum calculation tools do not exist, please install shasum/md5sum"
 		checksum_tools_on="1" # Do not repeat the message above
 	fi
-	unset checksum_sha1 checksum_sha256 checksum_sha512 checksum_md5 digest
+	unset checksum_sha1 checksum_sha256 checksum_sha512 checksum_md5 digest results
 }
 
 ################################################################################################################################################################


### PR DESCRIPTION
Hi @ivan-hc, this is a simple pull request to implement #2104, total of 48 lines. Here is the change summary:
- I have added _use_verify() function into APP-MANAGER, invoked via "am verify app" or "am -V app". It will compute the checksum of the app and then check the following sources for hashes, in sequence of availability:
  1. curl /opt/app/version.zsync (pkgforce repos always have these)
  2. curl /opt/app/version.DIGEST (some repos have these)
  3. curl /opt/app/verif (optional file containing a download page URL or similar, to be added by maintainers)

- Successful checksum verification will create /opt/app/AM-VERIFIED status file, which will result in a tick beside the version number in the generated table.
```
 - APPNAME      | VERSION          | TYPE           | SIZE
 ◆ gimp         | 3.0.8✓           | appimage       | 215 MiB
```

- Unsuccessful automatic verification will just prompt the user to manually verify the files, but a checksum mismatch will prompt the user to reinstall the app.

- If the shasum/md5sum tools are not available, AM will prompt the user to install them.

- I have updated the GIMP install script to add the download page URL into /opt/gimp/verif, as an example for how the verification function can still work when zsync/DIGEST files are not provided.
`echo "$DOWLOAD_PAGE" > ./verif`

- Updating or rolling back an app will remove the AM-VERIFIED file, if the app version is changed.

I have not yet added the use_verify function into -i or -u, because of the additional curl calls, and since it is still an experimental feature. It must be manually called for each app for now.

Interestingly, I actually did find one app in my database that failed verification (checksum mismatch). Updating it via am -u solved the problem, am verify shows successful verification.

I have not yet updated the documentation section.