### PR TITLE
Moved AM-VERIFIED removal to beginning of use_verify() function

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1410,6 +1410,7 @@ _use_sync() {
 _use_verify() {
 	# Check if checksum calc tools exist
 	if command -v sha1sum &>/dev/null && command -v sha256sum &>/dev/null && command -v sha512sum &>/dev/null && command -v md5sum &>/dev/null; then
+		[ -f "$argpath/AM-VERIFIED" ] && rm -f "$argpath"/AM-VERIFIED # Remove verified status
 		# Check if the download was a tarball/zip file
 		if { [ -f "$argpath/version" ] && grep -q '\.xz$\|\.zip$\|\.gz$' "$argpath/version"; } \
 		|| { [ -f "$argpath/AM-updater" ] && grep -q 'wget.*\.xz \|wget.*\.zip \|wget.*\.gz ' "$argpath/AM-updater"; } \
@@ -1447,15 +1448,13 @@ _use_verify() {
 			printf "%b⚠️\033[0m %b \n" "${Gold}" "$checksum_msg" | _fit
 			return 1
 		fi
-		# Calculate checksums and remove verified status
+		# Calculate checksums
 		if [ -f "$argpath"/"$arg" ]; then
-			rm -f "$argpath"/AM-VERIFIED
 			checksum_sha1=$(sha1sum "$argpath/$arg" | awk '{print $1}')
 			checksum_sha256=$(sha256sum "$argpath/$arg" | awk '{print $1}')
 			checksum_sha512=$(sha512sum "$argpath/$arg" | awk '{print $1}')
 			checksum_md5=$(md5sum "$argpath/$arg" | awk '{print $1}')
 		elif [ -f "$argpath"/"$pure_arg" ]; then
-			rm -f "$argpath"/AM-VERIFIED
 			checksum_sha1=$(sha1sum "$argpath/$pure_arg" | awk '{print $1}')
 			checksum_sha256=$(sha256sum "$argpath/$pure_arg" | awk '{print $1}')
 			checksum_sha512=$(sha512sum "$argpath/$pure_arg" | awk '{print $1}')


### PR DESCRIPTION
Refactored use_verify() removal of AM-VERIFIED, and moved it to the beginning of function so that verified apps can lose its verified status after an update (if zsync is missing).