### PR TITLE
Improve checksum verification

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1429,6 +1429,12 @@ _use_verify() {
 		if [ -n "$download_url" ]; then
 			# Search for zsync file
 			digest=$(curl -Ls "$download_url.zsync" | grep -a "SHA\|MD5")
+			# Search for sha256 file
+			if ! grep -q "https://github.com/" "$argpath"/version; then
+				if [ -z "$digest" ]; then
+					digest=$(curl -Ls "$download_url.sha256")
+				fi
+			fi
 			# Search for DIGEST file if no zsync file
 			if [ -z "$digest" ]; then
 				digest=$(curl -Ls "$download_url.DIGEST")


### PR DESCRIPTION
The first commit is "Checksum verification: check for sha256 file", that provides verified flag on some servers that are not github.com. I have tested this with `kdenlive` and works.

@vishnu350 take a look here.

I'm trying to solve the issue also for apps that are hosted on github.com

I won't deny that the new feature has caused quite a bit of alarm, as in the last five days I've been contacted by concerned people who hadn't read the release notes.

Many valid mainstream apps are marked as "unverified".

As I explained in the release notes, FAILURE TO VERIFY THE CHECKSUM DOESN'T MEAN THE APP IS INVALID. However, it's worth improving this feature to normalize the situation for less attentive users.