### PR TITLE
Added sha256 digest file checking, and softened checksum messages.

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1416,7 +1416,7 @@ _use_verify() {
 		if { [ -f "$argpath/version" ] && grep -q '\.xz$\|\.zip$\|\.gz$' "$argpath/version"; } \
 		|| { [ -f "$argpath/AM-updater" ] && grep -q 'wget.*\.xz \|wget.*\.zip \|wget.*\.gz ' "$argpath/AM-updater"; } \
 		|| { [ ! -f "$argpath/version" ] && [ ! -f "$argpath/AM-updater" ] && [ -f "$argpath/updater.ini" ]; }; then
-			checksum_msg=$(echo $"Checksum is not required for tarball/zip files.")
+			checksum_msg=$(echo $"Checksum auto-verified.")
 			printf "%b✔\033[0m %b \n" "${Green}" "$checksum_msg" | _fit
 			printf "Source is tarball/zip" > "$argpath"/AM-VERIFIED
 			return 1
@@ -1429,18 +1429,24 @@ _use_verify() {
 		if [ -n "$download_url" ]; then
 			# Search for zsync file
 			digest=$(curl -Ls "$download_url.zsync" | grep -a "SHA\|MD5")
-			# Search for DIGEST file if no zsync file
 			if [ -z "$digest" ]; then
+				# Search for DIGEST file if no zsync file
 				digest=$(curl -Ls "$download_url.DIGEST")
 				if echo "$digest" | grep -qi "not found"; then
-					if head -c10 "$argpath"/"$arg" 2>/dev/null | grep -qa '^.ELF....AI$' || head -c10 "$argpath"/"$pure_arg" 2>/dev/null | grep -qa '^.ELF....AI$'; then
-						checksum_msg=$(echo $"Checksum cannot be verified, no hashes found.")
-						printf "%b⚠️\033[0m %b \n" "${Gold}" "$checksum_msg" | _fit
+					# Search for sha256 file
+					digest=$(curl -Ls "$download_url.sha256")
+					if echo "$digest" | grep -qi "not found"; then
 						return 1
-					else
-						checksum_msg=$(echo $"Checksum verification not yet supported for this program.")
-						printf "%b?\033[0m %b \n" "${LightBlue}" "$checksum_msg" | _fit
-						return 1
+						## Disable these warnings?
+						#if head -c10 "$argpath"/"$arg" 2>/dev/null | grep -qa '^.ELF....AI$' || head -c10 "$argpath"/"$pure_arg" 2>/dev/null | grep -qa '^.ELF....AI$'; then
+						#	checksum_msg=$(echo $"Checksum cannot be verified, no hashes found.")
+						#	printf "%b⚠️\033[0m %b \n" "${Gold}" "$checksum_msg" | _fit
+						#	return 1
+						#else
+						#	checksum_msg=$(echo $"Checksum verification not yet supported for this program.")
+						#	printf "%b?\033[0m %b \n" "${LightBlue}" "$checksum_msg" | _fit
+						#	return 1
+						#fi
 					fi
 				fi
 			fi
@@ -1471,7 +1477,7 @@ _use_verify() {
 			checksum_msg=$(echo $"Checksum does not match, please manually verify file integrity.")
 			printf "%b✖\033[0m %b \n" "${RED}" "$checksum_msg" | _fit
 		else
-			checksum_msg=$(echo $"Checksum matches, verification successful.")
+			checksum_msg=$(echo $"Checksum verified.")
 			printf "%b✔\033[0m %b \n" "${Green}" "$checksum_msg" | _fit
 			printf "MD5: %b\nSHA1: %b\nSHA256: %b\nSHA512: %b" "$checksum_sha1" "$checksum_sha256" "$checksum_sha512" "$checksum_md5" > "$argpath"/AM-VERIFIED
 		fi


### PR DESCRIPTION
@ivan-hc I have added the sha256 digest file checking.

I have also commented out the 2 warnings that popup if no hashes are found, I feel they are not important to everyday users. What do you think? We can still see which apps are not verified using am -f.

But I left the errors (important) and success messages intact. The ✔ still shows. Errors will let the user be aware to re-install the app.

This way, users will not panic or become alarmed. Example output:
```
 ✔ YT-DLP is updated, 2 seconds elapsed!
 ✔ BLENDER is updated, 3 seconds elapsed! ✔ Checksum verified.
 ✔ GIMP is updated, 3 seconds elapsed!
 ✔ OPENRGB is updated, 3 seconds elapsed!
 ✔ KRITA is updated, 4 seconds elapsed! ✔ Checksum verified.
 ✔ KDENLIVE is updated, 4 seconds elapsed! ✔ Checksum verified.
 ✔ SAYONARA is updated, 5 seconds elapsed!
```