### PR TITLE
Source digest, DIGEST, sha512/256/1 and md5 for checksum

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1439,16 +1439,6 @@ _use_verify() {
 				done
 				if echo "$digest" | grep -qi "not found"; then
 					return 1
-					## Disable these warnings?
-					#if head -c10 "$argpath"/"$arg" 2>/dev/null | grep -qa '^.ELF....AI$' || head -c10 "$argpath"/"$pure_arg" 2>/dev/null | grep -qa '^.ELF....AI$'; then
-					#	checksum_msg=$(echo $"Checksum cannot be verified, no hashes found.")
-					#	printf "%b⚠️\033[0m %b \n" "${Gold}" "$checksum_msg" | _fit
-					#	return 1
-					#else
-					#	checksum_msg=$(echo $"Checksum verification not yet supported for this program.")
-					#	printf "%b?\033[0m %b \n" "${LightBlue}" "$checksum_msg" | _fit
-					#	return 1
-					#fi
 				fi
 			fi
 		else


### PR DESCRIPTION
This is an idea of @fiftydinar 

If `zsync` file is not hosted near the app, check the following file extensions, in this order:

1. digest
2. DIGEST
3. sha512
4. sha256
5. sha1
6. md5

@vishnu350 take a look at this change.