### PR TITLE
Updated app listing to display checksum verification failures.

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -849,7 +849,11 @@ _check_version() {
 			fi
 			APPVERSION=$(echo "$APPVERSION" | sed 's/  / /g; s/ $//g')
 			if [ -f "$argpath"/AM-VERIFIED ]; then
-				APPVERSION=$(echo "$APPVERSION✓" | awk '{gsub(/✓/, "\033[32m✓\033[0m"); print}')
+				if grep -q "Checksum failure" "$argpath"/AM-VERIFIED; then
+					APPVERSION=$(echo "$APPVERSION✖" | awk '{gsub(/✖/, "\033[31m✖\033[0m"); print}')
+				else
+					APPVERSION=$(echo "$APPVERSION✓" | awk '{gsub(/✓/, "\033[32m✓\033[0m"); print}')
+				fi
 			fi
 			if echo "$obsolete_apps" | grep -q "^$arg [0-9]"; then
 				obsolete_last_release=$(echo "$obsolete_apps" | grep "^$arg " | awk '{print $2}')
@@ -1467,6 +1471,7 @@ _use_verify() {
 		if [ -z "$results" ]; then
 			checksum_msg=$(echo $"Checksum does not match, please manually verify file integrity.")
 			printf "%b✖\033[0m %b \n" "${RED}" "$checksum_msg" | _fit
+			printf "Checksum failure" > "$argpath"/AM-VERIFIED
 		else
 			checksum_msg=$(echo $"Checksum verified.")
 			printf "%b✔\033[0m %b \n" "${Green}" "$checksum_msg" | _fit


### PR DESCRIPTION
This update will show apps that failed checksum verification, on the rare occasion that it does happen. Users may not have noticed the error during `am -u`, so this will help to remind them to reinstall the app.

```
 - APPNAME            | VERSION         | TYPE           | SIZE
 - -------            | -------         | ----           | ----
 ◆ cromite            | 145.0.7632.120✓ | appimage       | 183 MiB
 ◆ inkscape           | 1.4.3✖          | appimage       | 115 MiB

```