### PR TITLE
Allow am -u to redownload Appimages in the event of checksum failure

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1551,7 +1551,7 @@ _update_run_updater() {
 		fi
 	fi
 	if grep -sq "Checksum failure" "$argpath"/AM-VERIFIED; then
-		rm "$argpath"/version # Triggers AM-updater to re-download the Appimage binary
+		rm -f "$argpath"/version # Triggers AM-updater to re-download the Appimage binary
 	fi
 	if [ -z "$debug_update" ]; then
 		"$argpath"/AM-updater >/dev/null 2>&1


### PR DESCRIPTION
I added a check in _update_run_updater() to see if the checksum failed. If yes, it will delete the version file. This will force the AM-updater scripts to redownload the Appimage binary file.

Can be simulated and tested with the following steps:
1. Manually corrupt an Appimage using hexedit.
2. Run `am -u`, it will show checksum failure ✖. `am -f` will also show ✖.
3. Run `am -u` again, this time it will trigger the re-download and fix the error. `am -f` will show a green ✓.

This will negate the need to do a reinstall via `am -r app` and then `am -i app`