### PR TITLE
fix: handle empty HTTP body in digest checksum verification

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1437,11 +1437,13 @@ _use_verify() {
 				# Search other sources if no zsync file
 				for ext in digest DIGEST sha512 sha256 sha1 md5; do
 					digest=$(curl -Ls "$download_url.$ext")
+					# Skip empty responses (some CDNs return HTTP 404 with empty body)
+					[ -z "$digest" ] && continue
 					if ! echo "$digest" | grep -qi "not found\|access denied"; then
 						break
 					fi
 				done
-				if echo "$digest" | grep -qi "not found\|access denied"; then
+				if [ -z "$digest" ] || echo "$digest" | grep -qi "not found\|access denied"; then
 					return 1
 				fi
 			fi


### PR DESCRIPTION
## Summary

Fixes false "Checksum failure" reports for apps whose upstream releases do not provide sidecar digest files (`.sha256`, `.sha1`, `.md5`, etc.).

## Root Cause

When fetching digest files for checksum verification, some CDNs (notably GitHub) return **HTTP 404 with an empty body** instead of a `Not Found` text response. The digest-fetching loop breaks on these empty responses since they don't match the `not found|access denied` pattern, then proceeds to compare checksums against an empty digest string — which obviously never matches any hash.

**Reproduction:** Any AppImage from a GitHub release that does not ship `.sha256`/`.sha1`/`.md5` sidecar files (e.g. `ipfs-desktop`). The `.sha1` URL sometimes returns an empty 404 body:

```
$ curl -Ls "$url.sha1" | wc -c
0
```

This causes the loop to `break` with `digest=""`, which passes the `"not found"` check, enters the comparison logic, and writes `Checksum failure` to `AM-VERIFIED` — even though the actual file hash matches upstream perfectly.

## Fix

1. **In the loop:** skip empty responses with `[ -z "$digest" ] && continue`
2. **After the loop:** treat empty `$digest` as "no digest available" and return silently (same as the existing `"not found"` path)

This is a minimal, conservative fix — when no digest data is available, verification is silently skipped rather than falsely reporting failure.