### PR TITLE
fix: correct mismatched hash labels in AM-VERIFIED output

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1475,7 +1475,7 @@ _use_verify() {
 		else
 			checksum_msg=$(echo $"Checksum verified.")
 			printf "%b✔\033[0m %b \n" "${Green}" "$checksum_msg" | _fit
-			printf "MD5: %b\nSHA1: %b\nSHA256: %b\nSHA512: %b" "$checksum_sha1" "$checksum_sha256" "$checksum_sha512" "$checksum_md5" > "$argpath"/AM-VERIFIED
+			printf "MD5: %b\nSHA1: %b\nSHA256: %b\nSHA512: %b" "$checksum_md5" "$checksum_sha1" "$checksum_sha256" "$checksum_sha512" > "$argpath"/AM-VERIFIED
 		fi
 	else
 		echo $"Checksum calculation tools do not exist, please install coreutils." | sed 's/coreutils/"coreutils"/g'


### PR DESCRIPTION
## Summary

Fixes the printf argument order in `_use_verify()` so that hash labels in the `AM-VERIFIED` file match their actual values.

## Bug

The format string is `"MD5: %b\nSHA1: %b\nSHA256: %b\nSHA512: %b"` but the arguments were passed in the wrong order:

| Label | Was receiving | Should receive |
|-------|--------------|----------------|
| MD5 | `$checksum_sha1` | `$checksum_md5` |
| SHA1 | `$checksum_sha256` | `$checksum_sha1` |
| SHA256 | `$checksum_sha512` | `$checksum_sha256` |
| SHA512 | `$checksum_md5` | `$checksum_sha512` |

## Fix

Reorder the printf arguments to match their corresponding format labels:

```diff
-printf "MD5: %b\nSHA1: %b\nSHA256: %b\nSHA512: %b" "$checksum_sha1" "$checksum_sha256" "$checksum_sha512" "$checksum_md5"
+printf "MD5: %b\nSHA1: %b\nSHA256: %b\nSHA512: %b" "$checksum_md5" "$checksum_sha1" "$checksum_sha256" "$checksum_sha512"
```

This is a cosmetic bug — it does not affect pass/fail verification logic (the comparison at line 1470 checks all four hashes against the digest), but the `AM-VERIFIED` file contents were mislabeled.