### PR TITLE
Fixed use_verify curl calls to use the -f switch to simplify error detection

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.9.5-8"
+AMVERSION="9.9.5-9"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -1432,11 +1432,11 @@ _use_verify() {
 		fi
 		if [ -n "$download_url" ]; then
 			# Search for zsync file
-			digest=$(curl -Ls "$download_url.zsync" | grep -a "SHA\|MD5")
+			digest=$(curl -Lsf "$download_url.zsync" | grep -a "SHA\|MD5")
 			if [ -z "$digest" ]; then
 				# Search other sources if no zsync file
 				for ext in digest DIGEST sha512 sha256 sha1 md5; do
-					digest=$(curl -Ls "$download_url.$ext")
+					digest=$(curl -Lsf "$download_url.$ext")
 					# Skip empty responses (some CDNs return HTTP 404 with empty body)
 					[ -z "$digest" ] && continue
 					if ! echo "$digest" | grep -qi "not found\|access denied"; then


### PR DESCRIPTION
Based on discussion in issue #2184.