### PR TITLE
Terminology fixes for the term "Unofficial"

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ To change locations, remove local apps, and reinstall in the new location, see t
 "AM" installs, removes, updates and manages only standalone programs, ie those programs that can be run from a single directory in which they are contained.
 
 1. **PORTABLE PROGRAMS** from official sources (see Firefox, Thunderbird, NodeJS, Platform Tools...), extracted from official .deb/tar/zip packages.
-2. **APPIMAGES**, from both official and unofficial sources (I also create unofficial AppImages), or compiled on-the-fly with [pkg2appimage](https://github.com/AppImage/pkg2appimage) and [appimagetool](https://github.com/AppImage/AppImageKit), like an AUR helper, from official archives.
+2. **APPIMAGES**, from both official and community-maintained sources, or compiled on-the-fly with [pkg2appimage](https://github.com/AppImage/pkg2appimage) and [appimagetool](https://github.com/AppImage/AppImageKit), like an AUR helper, from official archives.
 3. **FIREFOX PROFILES** to run as webapps, the ones with suffix "ffwa-" in the apps list.
 4. **THIRD-PARTY LIBRARIES** if they are missing in your repositories.
 

--- a/docs/guides-and-tutorials/template.md
+++ b/docs/guides-and-tutorials/template.md
@@ -286,7 +286,7 @@ Their advantage is to keep the data of the reference site well separated from th
 ## How an installation script works
 The structure of an installation script is designed for a system-wide installation (as root), since it is intended to be hosted in this database. But every path indicated within it is written so that "`appman -i`" or "`am -i --user`" can patch the essential parts, to hijack the installation at a local level and without root privileges.
 
-This is a step-by-step focus on how an installation script runs, and we will take `brave` (official archive) and `brave-appimage` (the unofficial AppImage), you will see that they have a similar structure:
+This is a step-by-step focus on how an installation script runs, and we will take `brave` (official archive) and `brave-appimage` (community-maintained AppImage), you will see that they have a similar structure:
 1. The header, it is ment to set the `APP` and `SITE` variable
 ```
 #!/bin/sh

--- a/translations/README.md
+++ b/translations/README.md
@@ -72,7 +72,7 @@ Check your `$country_code` (see above) and download the `$country_code.po` file 
 
 ## Which programs to use?
 
-You can use an offline editor like [Poedit](https://poedit.net/download), available in almost all distribution repositories (see https://pkgs.org/download/poedit), and there is also an [unofficial AppImage](https://github.com/ivan-hc/Poedit-appimage) built by me, and installable via AM/AppMan (`am -i poedit` or `appman -i poedit`).
+You can use an offline editor like [Poedit](https://poedit.net/download), available in almost all distribution repositories (see https://pkgs.org/download/poedit), and there is also a [community-maintained AppImage](https://github.com/ivan-hc/Poedit-appimage) built by me, and installable via AM/AppMan (`am -i poedit` or `appman -i poedit`).
 
 Alternatively, use an online one: just search for "online .po editor" in your reference search engine and you will find several results, even free ones. These does not take up disk space and allows you to use your browser extensions, such as [this one](https://github.com/FilipePS/Traduzir-paginas-web) for Firefox-based browsers, to right-click and translate selected text.
 


### PR DESCRIPTION
We should really consider changing the term "Unofficial" into "Community-maintained" for Appimages in all documentation/listing/READMEs/scripts/repos.

The term "Community-maintained" (positive language) is a better term than "Unofficial" (negative language, sounds scary/suspicious to most people). If you search the news for the term "Community-built", you will see many positive articles, while "unofficial" gives you mostly negative articles.

The term "unofficial" Appimages only makes sense for closed-source software. It does not apply to open-source packaging flows. If we look at the entire Debian ecosystem and RPM repos, they are also building packages but no one calls them unofficial. All are maintained by open-source volunteers, with packaging flows that are open source and reproducible.

In this pull request I only made changes to the docs. If OK, I'll help to do the rest.