### PR TITLE
Updated install check condition to avoid app conflicts

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -596,7 +596,7 @@ case "$1" in
 			# Various cases that may occur during installation
 			if test -f "$APPSPATH"/"$pure_arg"/remove || test -f "$APPSPATH"/"$pure_arg"/remove.old; then
 				echo $" ◆ \"$pure_arg\" is already installed!" | tr '[:lower:]' '[:upper:]'
-			elif [ -n "$(command -v "$pure_arg" 2>/dev/null)" ] || [ -n "$(PATH=/usr/local/bin command -v "$pure_arg" 2>/dev/null)" ] || [ -n "$(PATH="$BINDIR" command -v "$pure_arg" 2>/dev/null)" ]; then
+			elif [ -n "$(PATH="$PATH":"$BINDIR":/usr/local/bin command -v "$pure_arg" 2>/dev/null)" ] ; then
 				echo $" 💀 ERROR: \"$pure_arg\" command already exists!"
 			elif echo "$arg" | grep -q "/"; then
 				if test -f "$arg" 2> /dev/null; then


### PR DESCRIPTION
Based on #2191 by @fiftydinar. Only one line changed in install.am.

Updated `am -i app` check conditions to detect if the app command exists and stop the installation to avoid conflicts between system, AM, and appman.

It doesn't make sense to install an app that already exists in the env from any of these sources.

Original code only checks if the app exists in /usr/local/bin AND if it is in AM mode. This is not good because a newer/different version may already exist in the system/appman and should be uninstalled first.

Rationale: If the user insists on installing it anyway, they should just download the install script and do it manually. By default, this should not be allowed as newer apps may corrupt existing configuration/settings that it uses for itself.