### PR TITLE
database.am: Make `-f`/files` faster, app size calculation accurate + show 2 decimals

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -592,19 +592,33 @@ _files_total_size() {
 	fi
 	APPLOCKED=""
 	INSTALLED_APPS_PLAN=$(echo "$INSTALLED_APPS_PATHS" | xargs)
-	[ -z "$INSTALLED_APPS_PLAN" ] && TOTAL_SIZE="0 KiB" || {
+	[ -z "$INSTALLED_APPS_PLAN" ] && TOTAL_SIZE="0.00B" || {
 		# Prefer summing exact bytes computed earlier to avoid re-scanning the filesystem and to provide precise totals.
 		if [ -n "$FILES_SIZES_BYTES_CONTENT" ]; then
 			# FILES_SIZES_BYTES_CONTENT lines are: " ◆ app	|	bytes"
 			# bytes is the 4th field
 			TOTAL_BYTES=$(echo "$FILES_SIZES_BYTES_CONTENT" | awk '{s+=$4}END{print s+0}')
-			# Convert to GiB with two decimals
-			TOTAL_GiB=$(awk -v b="$TOTAL_BYTES" 'BEGIN{printf "%.2f", b/1073741824}')
-			TOTAL_SIZE="$TOTAL_GiB GiB"
 		else
-			# Fallback: original method (may be slower)
-			TOTAL_SIZE=$(du -shc $INSTALLED_APPS_PLAN | awk 'END {print $1"iB"}' | sed 's/...$/ &/')
+			# Fallback: sum exact bytes with du -sb (may be slower)
+			TOTAL_BYTES=$(du -sb $INSTALLED_APPS_PLAN 2>/dev/null | awk '{s+=$1}END{print s+0}')
 		fi
+
+		# Format total using _hr_bytes (returns e.g. "123.00G" / "301.40M" / "199.00K" / "5.00B")
+		hr=$(_hr_bytes "$TOTAL_BYTES")
+		unit=${hr: -1}
+		case "$unit" in
+			G|M|K)
+				# append the 'iB' suffix for IEC units (GiB/MiB/KiB)
+				TOTAL_SIZE="${hr}iB"
+				;;
+			B)
+				# leave plain bytes as 'B'
+				TOTAL_SIZE="${hr}"
+				;;
+			*)
+				TOTAL_SIZE="${hr}iB"
+				;;
+		esac
 	}
 	echo $" TOTAL SIZE: $TOTAL_SIZE of disk space in use"
 	printf "\n"


### PR DESCRIPTION
# Explanation, comparison and benchmark

## Speed change

Benchmarked 100 times with `time` and calculated average time on my system with SSD and lots to calculate for apps files list, which can be seen in "Better app size calculation" section. This can be large if portable AppImage folders with its data are used.

Before:

- Cold run: 7.35s
- Warm run: 3.39s

After:

- Cold run: 5.26s
- Warm run: 2.40s

Cold run improvement: -2.09s
Warm run improvement: -0.99s

## Better app size calculation

App sizes were not quite accurate, it was off by around +1.5-2GiB on my system.

It also shows 2 decimals, so the app size is more clearly seen.

Before:

```
 YOU HAVE INSTALLED 30 PROGRAMS MANAGED BY "APPMAN"

 - APPNAME             | DB    | VERSION        | TYPE         | SIZE
 - -------             | --    | -------        | ----         | ----
 ◆ steam               | am    | 1.0.0.82 ✓     | appimage     | 124 GiB
 ◆ virtualbox          | am    | 7.2.6 ✓        | appimage     | 13 GiB
 ◆ wine                | extra | 11.5 ✓         | appimage     | 3,0 GiB
 ◆ discord             | am    | 0.0.129 ✓      | appimage     | 1,7 GiB
 ◆ supertuxkart        | extra | 1.5 ✓          | appimage     | 1,1 GiB
 ◆ supertux            | extra | 2 ✓            | appimage     | 302 MiB
 ◆ tutanota-enhanced   | am    | 338.260318.0 ✓ | appimage     | 185 MiB
 ◆ mpv                 | am    | 0.41.0 ✓       | appimage     | 150 MiB
 ◆ freetube            | extra | 0.23.15 ✓      | appimage     | 133 MiB
 ◆ video-trimmer       | am    | 25.03 ✓        | appimage     | 103 MiB
 ◆ varia               | am    | 2026.1.5.3 ✓   | appimage     | 103 MiB
 ◆ identity            | am    | 25.10.1 ✓      | appimage     | 94 MiB
 ◆ pinta               | am    | 3.1.1 ✓        | appimage     | 67 MiB
 ◆ gpu-screen-recorder | am    | 5.12.3 ✓       | appimage     | 62 MiB
 ◆ authenticator       | am    | 4.6.2 ✓        | appimage     | 61 MiB
 ◆ secrets             | am    | 12.3 ✓         | appimage     | 60 MiB
 ◆ mousai              | am    | 0.7.9 ✓        | appimage     | 59 MiB
 ◆ extension-manager   | am    | 0.6.5 ✓        | appimage     | 54 MiB
 ◆ rnote               | am    | 0.13.1 ✓       | appimage     | 49 MiB
 ◆ gpu-t               | am    | 0.1.3          | appimage     | 43 MiB
 ◆ localsend           | extra | 1.17.0 ✓       | appimage     | 40 MiB
 ◆ tuxfootball         | am    | 0.3.1 ✓        | appimage     | 39 MiB
 ◆ eyedropper          | am    | 2.1.0 ✓        | appimage     | 36 MiB
 ◆ featherpad          | am    | 1.6.3 ✓        | appimage     | 32 MiB
 ◆ gnome-calculator    | am    | 49.2 ✓         | appimage     | 31 MiB
 ◆ collision           | am    | 3.14.0 ✓       | appimage     | 27 MiB
 ◆ tuxpuck             | extra | 0.8.2 ✓        | appimage     | 24 MiB
 ◆ appimageupdatetool  | am    | a76b0ca08 ✓    | appimage     | 5,9 MiB
 ◆ sas                 | am    | 1.8 ✓          | appimage     | 3,6 MiB
 ◆ xdg-ninja**         | am    | 0.2.0.2 ✓      | posix-script | 1,7 MiB

 TOTAL SIZE: 144 GiB of disk space in use

 **the following app may have security vulnerabilities or is outdated:

  ◆ xdg-ninja: the last release dates back to 2024

 Please report more up-to-date sources, otherwise remove this app and look for alternatives.
```

After:

```
 YOU HAVE INSTALLED 30 PROGRAMS MANAGED BY "APPMAN"

 - APPNAME             | DB    | VERSION        | TYPE         | SIZE
 - -------             | --    | -------        | ----         | ----
 ◆ steam               | am    | 1.0.0.82 ✓     | appimage     | 123 GiB
 ◆ virtualbox          | am    | 7.2.6 ✓        | appimage     | 12 GiB
 ◆ wine                | extra | 11.5 ✓         | appimage     | 3.0 GiB
 ◆ discord             | am    | 0.0.129 ✓      | appimage     | 1.6 GiB
 ◆ supertuxkart        | extra | 1.5 ✓          | appimage     | 1.0 GiB
 ◆ supertux            | extra | 2 ✓            | appimage     | 301.4 MiB
 ◆ tutanota-enhanced   | am    | 338.260318.0 ✓ | appimage     | 188.9 MiB
 ◆ mpv                 | am    | 0.41.0 ✓       | appimage     | 137.1 MiB
 ◆ freetube            | extra | 0.23.15 ✓      | appimage     | 130.8 MiB
 ◆ video-trimmer       | am    | 25.03 ✓        | appimage     | 101.8 MiB
 ◆ varia               | am    | 2026.1.5.3 ✓   | appimage     | 101.0 MiB
 ◆ identity            | am    | 25.10.1 ✓      | appimage     | 92.7 MiB
 ◆ pinta               | am    | 3.1.1 ✓        | appimage     | 66.1 MiB
 ◆ gpu-screen-recorder | am    | 5.12.3 ✓       | appimage     | 60.3 MiB
 ◆ authenticator       | am    | 4.6.2 ✓        | appimage     | 59.2 MiB
 ◆ secrets             | am    | 12.3 ✓         | appimage     | 59.1 MiB
 ◆ mousai              | am    | 0.7.9 ✓        | appimage     | 57.3 MiB
 ◆ extension-manager   | am    | 0.6.5 ✓        | appimage     | 52.6 MiB
 ◆ rnote               | am    | 0.13.1 ✓       | appimage     | 47.6 MiB
 ◆ gpu-t               | am    | 0.1.3          | appimage     | 42.7 MiB
 ◆ localsend           | extra | 1.17.0 ✓       | appimage     | 38.8 MiB
 ◆ tuxfootball         | am    | 0.3.1 ✓        | appimage     | 38.3 MiB
 ◆ eyedropper          | am    | 2.1.0 ✓        | appimage     | 35.2 MiB
 ◆ featherpad          | am    | 1.6.3 ✓        | appimage     | 31.2 MiB
 ◆ gnome-calculator    | am    | 49.2 ✓         | appimage     | 30.5 MiB
 ◆ collision           | am    | 3.14.0 ✓       | appimage     | 25.5 MiB
 ◆ tuxpuck             | extra | 0.8.2 ✓        | appimage     | 23.2 MiB
 ◆ appimageupdatetool  | am    | a76b0ca08 ✓    | appimage     | 5.8 MiB
 ◆ sas                 | am    | 1.8 ✓          | appimage     | 3.5 MiB
 ◆ xdg-ninja**         | am    | 0.2.0.2 ✓      | posix-script | 199 KiB

 TOTAL SIZE: 142.69 GiB of disk space in use

 **the following app may have security vulnerabilities or is outdated:

  ◆ xdg-ninja: the last release dates back to 2024

 Please report more up-to-date sources, otherwise remove this app and look for alternatives.
```

## Other thoughts

Please report your findings, if some dependencies are not POSIX, if something can be done better.

Feel free to remove the comments, those were inserted by GPT 5 Mini, I made this with the help of AI.

So far in my testing, nothing broke.