### PR TITLE
Added two regression test scripts.

### DIFF
--- a/regress/am_checksum_test.sh
+++ b/regress/am_checksum_test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Error checking function
+_check_count () {
+if [ "$(grep -i "$2" "$1" | wc -l)" != "$3" ]; then
+	echo Error: Test failed, $2 should occur $3 times.
+	exit
+fi
+}
+
+# Test install (system)
+am --system
+am -r zsync2
+am -i zsync2 > .results
+
+# Check for errors
+_check_count .results "checksum verified" 1
+
+# Pass the test if all was good
+echo "Test passed!"
+

--- a/regress/am_install_test.sh
+++ b/regress/am_install_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Error checking function
+_check_count () {
+if [ "$(grep -i $2 $1 | wc -l)" != $3 ]; then
+	echo Error: Test failed, $2 should occur $3 times.
+	exit
+fi
+}
+
+# Test install (system)
+am --system
+am -i zsync2
+
+# Test install (user)
+am --user
+am -i zsync2
+
+# Check listing
+am --system
+
+# Check for errors
+am -f > .results
+_check_count .results zsync2 2
+
+# Test removal
+am --user
+am -r zsync2
+
+# Check for errors
+am -f > .results
+_check_count .results zsync2 1
+
+# Test removal
+am --system
+am -r zsync2
+
+# Check for errors
+am -f > .results
+_check_count .results zsync2 0
+
+# Pass the test if all was good
+echo "Test passed!"
+


### PR DESCRIPTION
@ivan-hc, @fiftydinar.

These are two simple tests that can be run independently by testers on their systems to help with regression testing. They will display either **pass** or **fail** to help with debugging. 

The idea is we should add more tests here to catch problems that occur in the future like sandboxing failure etc, and run all of them before triggering a release.

Added two sample regression scripts.
1. am_install_test.sh - Installs two apps with the same name and checks if they are listed correctly.
2. am_checksum_test.sh - Installs an app with known checksum verified status and checks if it was verified correctly.

NOTE: I hardcoded zsync2 in the test script because it is a small download. Usually test devs will randomize this for testing, but what if it randomly picks blender (1GB file).