### PR TITLE
"AM" 10.1 - Custom PATH for appimagetool if not present

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -540,15 +540,32 @@ _online_check() {
 	fi
 }
 
+# Check AMCACHEPATH integrity
+if [ -d "$CACHEDIR"/AMCACHEPATH ]; then
+	am_bins_allowed=$(echo "appimagetool busybox cat column chmod chown curl file grep less sed wget" | tr ' ' '\n' | sed "s#^#$CACHEDIR/AMCACHEPATH/#g")
+	am_bins_directories=$(find "$CACHEDIR"/AMCACHEPATH/* -type d)
+	am_bins_files=$(find "$CACHEDIR"/AMCACHEPATH/* -type f)
+	for d in $am_bins_directories; do rmdir "${d}" 2>/dev/null; done
+	for f in $am_bins_files; do if ! echo "$am_bins_allowed" | grep -q "$f" 2>/dev/null; then rm "$f" 2>/dev/null; fi; done
+fi
+
 # Check if appimagetool is installed, and if it is not installed, download and use it where it is needed
 _download_appimagetool() {
+	_determine_args
 	if ! command -v appimagetool >/dev/null 2>&1; then
 		mkdir -p "$CACHEDIR"/AMCACHEPATH
 		if [ ! -f "$CACHEDIR"/AMCACHEPATH/appimagetool ]; then
+			_online_check
 			wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-"$(uname -m)".AppImage -O "$CACHEDIR"/AMCACHEPATH/appimagetool
 			chmod a+x "$CACHEDIR"/AMCACHEPATH/appimagetool
 		fi
-		export PATH="$CACHEDIR"/AMCACHEPATH/:"${PATH}"
+	fi
+	if ! echo "$ARGPATHS" | grep -q "/appimagetool$"; then
+		if ! echo "$PATH" | grep -q "AMCACHEPATH"; then
+			export PATH="$CACHEDIR"/AMCACHEPATH/:"${PATH}"
+		fi
+	else
+		rm -f "$CACHEDIR"/AMCACHEPATH/appimagetool
 	fi
 }
 

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="10"
+AMVERSION="10.1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -540,6 +540,18 @@ _online_check() {
 	fi
 }
 
+# Check if appimagetool is installed, and if it is not installed, download and use it where it is needed
+_download_appimagetool() {
+	if ! command -v appimagetool >/dev/null 2>&1; then
+		mkdir -p "$CACHEDIR"/AMCACHEPATH
+		if [ ! -f "$CACHEDIR"/AMCACHEPATH/appimagetool ]; then
+			wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-"$(uname -m)".AppImage -O "$CACHEDIR"/AMCACHEPATH/appimagetool
+			chmod a+x "$CACHEDIR"/AMCACHEPATH/appimagetool
+		fi
+		export PATH="$CACHEDIR"/AMCACHEPATH/:"${PATH}"
+	fi
+}
+
 # BLACKLIST FILES
 appimagelauncher_msg="Your installation of AppImageLauncher may have been done via DEB, RPM, or AUR, which interrupts the natural operation of \"systemd-binfmt\" in addition to launching the aforementioned daemon. To avoid problems with \"$AMCLIUPPER\" and any other AppImages helper, it's preferable to use \"only\" the standalone AppImage of AppImageLauncher, whose official updated release can also be installed via \"$AMCLIUPPER\". But as long as you have the currently installed version, you can't use this CLI."
 
@@ -1150,6 +1162,12 @@ _clean_old_modules() {
 	done
 }
 
+_clean_amcachepath() {
+	if [ -d "$CACHEDIR"/AMCACHEPATH ] && [ "$(ls -A "$CACHEDIR"/AMCACHEPATH)" ]; then
+		rm -f "$CACHEDIR"/AMCACHEPATH/* && echo $" ✔ Clear the contents of $CACHEDIR/appman" | sed 's#/appman$#/AMCACHEPATH#g'
+	fi
+}
+
 _use_clean() {
 	echo $" Cleaning temporary files and folders..." && sleep 0.1
 	i=100 && while [ "$i" -ge 0 ]; do
@@ -1162,6 +1180,7 @@ _use_clean() {
 	_clean_all_tmp_directories_from_appspath
 	_clean_launchers 2>/dev/null
 	_clean_old_modules
+	_clean_amcachepath
 }
 
 ################################################################################################################################################################
@@ -1721,6 +1740,7 @@ _use_update() {
 	_update_github_api_key_in_the_updater_files
 	_clean_all_tmp_directories_from_appspath >/dev/null
 	_check_fedora_mess
+	_download_appimagetool
 
 	ENTRIES="$(echo "$@" | cut -f2- -d ' ' | tr ' ' '\n' | grep -v -- "^-\|^$1$")"
 	FLAGS=$(echo "$@" | tr ' ' '\n' | grep -- "--" | tr '\n ' ' ')

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -542,11 +542,9 @@ _online_check() {
 
 # Check AMCACHEPATH integrity
 if [ -d "$CACHEDIR"/AMCACHEPATH ]; then
-	am_bins_allowed=$(echo "appimagetool busybox cat column chmod chown curl file grep less sed wget" | tr ' ' '\n' | sed "s#^#$CACHEDIR/AMCACHEPATH/#g")
-	am_bins_directories=$(find "$CACHEDIR"/AMCACHEPATH/* -type d)
-	am_bins_files=$(find "$CACHEDIR"/AMCACHEPATH/* -type f)
-	for d in $am_bins_directories; do rmdir "${d}" 2>/dev/null; done
-	for f in $am_bins_files; do if ! echo "$am_bins_allowed" | grep -q "$f" 2>/dev/null; then rm "$f" 2>/dev/null; fi; done
+	am_bins_allowed=$(echo "appimagetool" | tr ' ' '\n' | sed "s#^#$CACHEDIR/AMCACHEPATH/#g")
+	am_bins_all=$(find "$CACHEDIR"/AMCACHEPATH -mindepth 1 -maxdepth 1 \( -type d -o -type f -o -type l \))
+	for f in $am_bins_all; do if ! echo "$am_bins_allowed" | grep -q "$f$" 2>/dev/null; then rm "$f" 2>/dev/null; fi; done
 fi
 
 # Check if appimagetool is installed, and if it is not installed, download and use it where it is needed
@@ -1757,7 +1755,6 @@ _use_update() {
 	_update_github_api_key_in_the_updater_files
 	_clean_all_tmp_directories_from_appspath >/dev/null
 	_check_fedora_mess
-	_download_appimagetool
 
 	ENTRIES="$(echo "$@" | cut -f2- -d ' ' | tr ' ' '\n' | grep -v -- "^-\|^$1$")"
 	FLAGS=$(echo "$@" | tr ' ' '\n' | grep -- "--" | tr '\n ' ' ')

--- a/modules/install.am
+++ b/modules/install.am
@@ -156,6 +156,7 @@ _check_kind_of_installation_script() {
 	# Check if you are installing an app or a library
 	echo $" ◆ $APPNAME: starting installation script"
 	if grep -qi "^wget.*.sh.*chmod.*&&\|^curl.*main/portable2appimage" ./"$arg"; then
+		_download_appimagetool
 		printf $"\n This script will create an AppImage on the fly, please wait...\n"
 	elif grep -q "/usr/local/lib" ./"$arg"; then
 		[ "$arg" = libfuse2 ] && [ -f /usr/local/lib/libfuse.so.2 ] && echo $" 💀 ERROR: \"$arg\" already exists in /usr/local/lib" && return 1

--- a/modules/management.am
+++ b/modules/management.am
@@ -445,13 +445,7 @@ _nolibfuse() {
 		return 1
 	fi
 
-	# If appimagetool is not installed, download it
-	if ! command -v appimagetool 1>/dev/null; then
-		_online_check
-		printf $" ...downloading appimagetool\r"
-		wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage" -O ./appimagetool || return 1
-		chmod a+x ./appimagetool
-	fi
+	_download_appimagetool # If appimagetool is not installed, download it
 
 	# Extract the AppImage
 	printf $" ...extracting the AppImage\r"
@@ -468,22 +462,18 @@ _nolibfuse() {
 
 	# Convert the AppImage to a new generation one
 	printf $" ...trying to convert in new generation AppImage\r"
-	if [ -f ./appimagetool ]; then
-		PATH="$PATH:$PWD" ARCH="$(uname -m)" ./appimagetool -n ./squashfs-root >/dev/null 2>&1
-	elif command -v appimagetool 1>/dev/null; then
-		ARCH="$(uname -m)" appimagetool -n ./squashfs-root >/dev/null 2>&1
-	fi
+	ARCH="$(uname -m)" appimagetool -n ./squashfs-root >/dev/null 2>&1
 
 	# Test if the AppImage has been created
 	if ! test -f ./*.AppImage; then
 		echo $" 💀Error when trying to convert $target. Operation Aborted."
-		rm -Rf ./appimagetool ./squashfs-root
+		rm -Rf ./squashfs-root
 		return 1
 	fi
 
 	mv ./"$2" ./"$2".old && mv ./*.AppImage ./"$2" || return 1
 	echo $" ◆ $target has been converted to a new generation AppImage."
-	rm -Rf ./appimagetool ./squashfs-root ./*.zsync
+	rm -Rf ./squashfs-root ./*.zsync
 	if [ -f ./AM-updater ] && ! grep -q 'nolibfuse' ./AM-updater; then
 		sed -i "s/^else/	echo y | $AMCLIPATH_ORIGIN nolibfuse \"\$APP\"\n	notify-send \"\$APP has been converted too\!\"\nelse/g" ./AM-updater 2>/dev/null
 		echo $" The next update may replace this AppImage with a Type2 one"


### PR DESCRIPTION
This will be downloaded and saved in "$CACHEDIR"/AMCACHEPATH

Once downloaded, "$CACHEDIR"/AMCACHEPATH will be exported in $PATH, so `appimagetool` will be available in the following cases:
- when an app installed (option `-i`) is an AppImage built on-the-fly
- when an old AppImage must be converted to a new one to remove libfuse2 dependency (option `nolibfuse`)

To remove the content of "$CACHEDIR"/AMCACHEPATH, run the option `-c` or `clean`.

This is the first step for an even bigger implementation of portable dependencies throwaway for AM.

@fiftydinar @Samueru-sama @vishnu350 