### PR TITLE
antigravity: fix desktop file installation and add URL handler

### DIFF
--- a/programs/x86_64/antigravity
+++ b/programs/x86_64/antigravity
@@ -8,7 +8,7 @@ SITE="https://antigravity.google"
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
-printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop /usr/local/share/applications/$APP-url-handler-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
@@ -59,21 +59,21 @@ EOF
 chmod a+x ./AM-updater || exit 1
 
 # LAUNCHER & ICON
-./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
-./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
-COUNT=0
-while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
-	if [ -L ./"$APP".desktop ]; then
-		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
-		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
-	fi
-	if [ -L ./DirIcon ]; then
-		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
-		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
-	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
-	COUNT=$((COUNT + 1))
-done
-sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./"$APP".desktop
-mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+./"$APP" --appimage-extract 1>/dev/null
+desktop_main=$(find ./squashfs-root -name "$APP.desktop" | head -1)
+desktop_url=$(grep -rl "NoDisplay=true" ./squashfs-root --include="*.desktop" | head -1)
+if [ -n "$desktop_main" ]; then
+	sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" "$desktop_main"
+	cp "$desktop_main" /usr/local/share/applications/"$APP"-AM.desktop
+fi
+if [ -n "$desktop_url" ]; then
+	sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" "$desktop_url"
+	cp "$desktop_url" /usr/local/share/applications/"$APP"-url-handler-AM.desktop
+fi
+if [ -f ./squashfs-root/.DirIcon ]; then
+	cp ./squashfs-root/.DirIcon ./icons/"$APP"
+else
+	icon_src=$(find ./squashfs-root -name "*.png" -o -name "*.svg" | head -1)
+	[ -n "$icon_src" ] && cp "$icon_src" ./icons/"$APP"
+fi
 rm -R -f ./squashfs-root


### PR DESCRIPTION
The .deb package contains two desktop files: the main launcher (antigravity.desktop) and a URL handler (with NoDisplay=true). The previous script used --appimage-extract *.desktop which only matched files at the squashfs root, but portable2appimage preserves the original .deb structure with files nested under usr/share/applications/. This caused desktop file extraction to fail silently, so the app never appeared in the system menu.

Additionally, when extraction happened to work, the glob could pick up the URL handler instead of the main launcher entry.

Fixes:
- Switch to full --appimage-extract and use find to locate desktop files
- Install main launcher as $APP-AM.desktop (shown in menu)
- Install URL handler as $APP-url-handler-AM.desktop (NoDisplay=true, for mime)
- Update remove script to clean up both desktop files on uninstall
- Icon extraction falls back to first .png/.svg if .DirIcon is absent