### PR TITLE
Update FreeCAD download source in installation script

### DIFF
--- a/programs/x86_64/freecad
+++ b/programs/x86_64/freecad
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=freecad
-SITE="FreeCAD/FreeCAD-Bundle"
+SITE="FreeCAD/FreeCAD"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/FreeCAD/FreeCAD-Bundle/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/FreeCAD/FreeCAD/releases | sed 's/[()",{} ]/\n/g' | grep -vi 'weekly' | grep -vi 'Candidate' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -31,9 +31,9 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=freecad
-SITE="FreeCAD/FreeCAD-Bundle"
+SITE="FreeCAD/FreeCAD"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/FreeCAD/FreeCAD-Bundle/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/FreeCAD/FreeCAD/releases | sed 's/[()",{} ]/\n/g' | grep -vi 'weekly' | grep -vi 'Candidate' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1


### PR DESCRIPTION
Unfortunately the repo FreeCAD-Bundle isn't kept up to date. Last listed release is from August 2025. (V1.0.1)

New releases are available in the FreeCAD/FreeCAD repo. I've adapted the repo path and added exclusion grep for weekly builds and release candidates to only capture official releases.