### PR TITLE
Added POSIX compliant regression testing flow

### DIFF
--- a/regress/am-debian.dockerfile
+++ b/regress/am-debian.dockerfile
@@ -1,6 +1,6 @@
 ## To run this image using podman:
 ## 1. podman build -t am-debian -f am-debian.dockerfile
-## 2. podman run -it --device /dev/fuse --cap-add SYS_ADMIN debian:latest /bin/bash
+## 2. podman run -it --device /dev/fuse --cap-add SYS_ADMIN am-debian:latest /bin/bash
 
 # Use the official Debian image as a parent image
 FROM debian:latest

--- a/regress/am-debian.dockerfile
+++ b/regress/am-debian.dockerfile
@@ -1,0 +1,28 @@
+## To run this image using podman:
+## 1. podman build -t am-debian -f am-debian.dockerfile
+## 2. podman run -it --device /dev/fuse --cap-add SYS_ADMIN debian:latest /bin/bash
+
+# Use the official Debian image as a parent image
+FROM debian:latest
+
+# Install dependencies and AM
+RUN apt update && apt full-upgrade -y && apt install -y sudo wget curl git fuse bsdextrautils file locales unzip
+RUN cd && wget https://raw.githubusercontent.com/ivan-hc/AM/main/INSTALL && chmod a+x ./INSTALL && sudo ./INSTALL && rm ./INSTALL
+RUN cd && git clone https://github.com/ivan-hc/AM AM
+
+# Copy regression folder
+COPY ../regress /root/regress
+
+# Setup locale
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN locale-gen && update-locale LANG=en_US.UTF-8
+RUN export LC_ALL=en_US.UTF-8
+
+# Setup env
+RUN echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc
+RUN echo "cd" >> ~/.bashrc
+
+# Done
+RUN echo "Container ready!"
+CMD ["/bin/bash"]
+

--- a/regress/test-am-checksum.sh
+++ b/regress/test-am-checksum.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+# Source common test functions
+. "$(dirname "$0")/test-common.sh"
+
+# Test variables
+test_results=".results.tmp"
+app_name1=$(_pick_random_app "$TEST_APP_LIST_ZSYNC")
+TEST_APP_LIST_ZSYNC=$(_remove_item "$TEST_APP_LIST_ZSYNC" "$app_name1")
+app_name2=$(_pick_random_app "$TEST_APP_LIST_ZSYNC")
+app_name_digest=$(_pick_random_app "$TEST_APP_LIST_DIG")
+app_name_zip=$(_pick_random_app "$TEST_APP_LIST_ZIP")
+app_name_nochk=$(_pick_random_app "$TEST_APP_LIST_NOCHK")
+
+# Remove all apps first
+am --system
+am -r "$app_name1" "$app_name2" "$app_name_digest" "$app_name_zip" "$app_name_nochk"
+
+# Test install
+am -i "$app_name1" > "$test_results"
+_check_count "checksum verified" 1 "$test_results"
+
+# Test install for another app
+am -i "$app_name2" > "$test_results"
+_check_count "checksum verified" 1 "$test_results"
+
+# Test install for app with digest files
+am -i "$app_name_digest" > "$test_results"
+_check_count "checksum verified" 1 "$test_results"
+
+# Test install for app that are tarballs/zip files
+am -i "$app_name_zip" > "$test_results"
+_check_count "checksum auto-verified" 1 "$test_results"
+
+# Test install for app with no zsync files (checksum wont be verified)
+am -i "$app_name_nochk" > "$test_results"
+_check_count "checksum verified" 0 "$test_results"
+
+# Pass the test if all was good
+_log "Test passed!"
+

--- a/regress/test-am-install.sh
+++ b/regress/test-am-install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+
+# Source common test functions
+. "$(dirname "$0")/test-common.sh"
+
+# Test variables
+test_results=".results.tmp"
+app_name=$(_pick_random_app "$TEST_APP_LIST_ZIP")
+
+# Install in System Mode
+_log "Installing $app_name in system mode..."
+am --system
+am -i "$app_name"
+
+# Install in User Mode
+_log "Installing $app_name in user mode..."
+am --user
+am -i "$app_name"
+
+# Check Listing
+_log "Checking if $app_name is installed in both user/system modes..."
+am --system
+am -f > "$test_results"
+_check_count "$app_name" 2 "$test_results"
+
+# Remove in User Mode
+_log "Removing $app_name in user mode..."
+am --user
+am -r "$app_name"
+
+# Check for Errors
+_log "Checking if $app_name is removed from user mode..."
+am -f > "$test_results"
+_check_count "$app_name" 0 "$test_results"
+
+# Remove in System Mode
+_log "Removing $app_name in system mode..."
+am --system
+am -r "$app_name"
+
+# Check for Errors
+_log "Checking if $app_name is removed from system mode..."
+am -f > "$test_results"
+_check_count "$app_name" 0 "$test_results"
+
+# Clean up test results file
+rm -f "$test_results"
+
+# Pass the test if all was good
+_log "Test passed!"
+

--- a/regress/test-common.sh
+++ b/regress/test-common.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+
+# List of test apps (REQUIREMENTS: Under 20MB, has .zsync, simple install script)
+TEST_APP_LIST_ZSYNC="zsync2 xeyes rofi foot pavucontrol-qt"
+
+# List of test apps with DIGEST files (REQUIREMENTS: Under 20MB, a digest file, simple install script)
+TEST_APP_LIST_DIG="keepassxc"
+
+# List of test apps that are zipped (REQUIREMENTS: Under 10MB, no .zsync, simple install script)
+TEST_APP_LIST_ZIP="clifm cheat doggo dra nyan navi lsd hyperfine fcp"
+
+# List of test apps that cant be verified (REQUIREMENTS: Under 10MB, no .zsync/digest, not zipped, simple install script)
+TEST_APP_LIST_NOCHK="bench-cli helio appimagen appimageupdate crabfetch"
+
+# Function to randomly pick an app from a list
+_pick_random_app() {
+	# Get count
+	list_lines=$(echo "$1" | tr ' ' '\n' | sed '/^\s*$/d') # Convert to vertical list and remove empty lines
+	count=$(echo "$list_lines" | wc -l)
+
+	# Check if list is empty
+	if [ "$count" -eq 0 ]; then
+		return 1
+	fi
+
+	# Pick a random app
+	random_index=$(($(od -An -N2 -tu2 /dev/urandom | tr -d ' ') % count + 1))
+	picked=$(echo "$list_lines" | sed -n "${random_index}p")
+
+	# Output both picked item and new list
+	echo "$picked"
+}
+
+# Function to remove an app from a list
+_remove_item() {
+	#Variables
+	list="$1"
+	item_to_remove="$2"
+	new_list=""
+
+	# Iterate and remove item
+	for item in $list; do
+		if [ "$item" != "$item_to_remove" ]; then
+			new_list="$new_list $item"
+		fi
+	done
+
+	# Output both picked item and new list
+	echo "$new_list"
+}
+
+# Function to check the count of a specific message/text in the results
+_check_count() {
+	chk_msg_name="$1"
+	chk_expected_count="$2"
+	chk_file="$3"
+	chk_actual_count=$(grep -ic "$chk_msg_name" "$chk_file")
+
+	# Check msg count
+	if [ "$chk_actual_count" -ne "$chk_expected_count" ]; then
+		echo "Error: Test failed, $chk_msg_name should occur $chk_expected_count times, but found $chk_actual_count times."
+		exit 1
+	fi
+}
+
+# Function to log messages
+_log() {
+	echo "$1"
+}
+


### PR DESCRIPTION
I have added a POSIX sh compliant test flow that can be run independently by testers on their systems to help with regression testing. They will display either pass or fail at the end of the test, and will help prevent a broken version of AM to be shipped.

The following are the files added. All scripts are **POSIX sh compliant** and will run in any OS.
- `test-common.sh`
  - Houses all common functions for all tests.
  - Contains TEST_APP_LIST* that contains a list of predefined apps to be randomly selected for testing.
  - All apps in the test list are selected to be small downloads, and do not have complex install scripts.
- `test-am-install.sh` - Installs two apps with the same name and checks if they are listed correctly.
- `test-am-checksum.sh` - Installs several apps with known checksum statuses and checks if it was verified correctly (or not).
- `am-debian.dockerfile` - To build a Debian container image with the correct environment for testing, properly setup to work with AM out-of-the-box.

Test steps (requires podman):
1. Clone AM repo and go to regression dir:
`cd regress`
3. Build am-debian container image:
`podman build -t am-debian -f am-debian.dockerfile`
4. Start am-debian container session:
`podman run -it --device /dev/fuse --cap-add SYS_ADMIN am-debian:latest /bin/bash`
5. Run tests (already copied into container):
`cd regress`
`./test-am-checksum.sh`
`./test-am-install.sh`

Future plans:
- Add more tests - sandbox, hide/unhide, etc.
- Add more OS dockerfile images - BSD, Redhat, Fedora, Arch, etc.
- Add documentation on how to run tests in `docs/guides-and-tutorials/testing.md`.
- Improve logging mechanism and catch errors as reported by AM.
- Update AM to support better error messages so that it is easier to grep and catch.
- Update AM to support unattended mode so that we don't need to key in Y/N to speed up testing.