### PR TITLE
Regression testing updates (+rollback test)

### DIFF
--- a/regress/am-debian.dockerfile
+++ b/regress/am-debian.dockerfile
@@ -16,8 +16,8 @@ RUN cd && git clone --depth 1 https://github.com/ivan-hc/AM && mv AM/regress . &
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN locale-gen && update-locale LANG=en_US.UTF-8
 
-# Setup AM user mode to use default path
-RUN printf "y\n\n" | am --user && am --system
+# Setup AM with safe defaults
+RUN printf "y\n\n" | am --user && am --system && am --disable-notifications
 
 # Setup env
 RUN echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc

--- a/regress/am-ubuntu.dockerfile
+++ b/regress/am-ubuntu.dockerfile
@@ -16,8 +16,8 @@ RUN cd && git clone --depth 1 https://github.com/ivan-hc/AM && mv AM/regress . &
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
 RUN locale-gen && update-locale LANG=en_US.UTF-8
 
-# Setup AM user mode to use default path
-RUN printf "y\n\n" | am --user && am --system
+# Setup AM with safe defaults
+RUN printf "y\n\n" | am --user && am --system && am --disable-notifications
 
 # Setup env
 RUN echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc

--- a/regress/test-am-hide.sh
+++ b/regress/test-am-hide.sh
@@ -10,16 +10,34 @@ app_name2=$(_pick_random_app "$TEST_APP_LIST_ZIP")
 
 ## Setup
 _log "Running hide/unhide test: $0"
-am --system
 
-# Install apps
+# Install app locally
+printf "y\n" |\
+am --user
+am -i "$app_name1"
+
+# Test hide
+_log "Test hide $app_name1 (local)..."
+am hide "$app_name1"
+am -f > "$test_results"
+_check_count "$app_name1.*|" 0 "$test_results"
+
+# Test unhide
+_log "Test unhide $app_name1 (local)..."
+am unhide "$app_name1"
+am -f > "$test_results"
+_check_count "$app_name1.*|" 1 "$test_results"
+
+# Install apps in system level
+am --system
 am -i "$app_name1" "$app_name2"
 
 # Test hide
 _log "Test hide $app_name1..."
+printf "1\n" |\
 am hide "$app_name1"
 am -f > "$test_results"
-_check_count "$app_name1.*|" 0 "$test_results"
+_check_count "$app_name1.*|" 1 "$test_results"
 
 # Test hide for another app
 _log "Test hide $app_name2..."
@@ -31,7 +49,7 @@ _check_count "$app_name2.*|" 0 "$test_results"
 _log "Test unhide $app_name1..."
 am unhide "$app_name1"
 am -f > "$test_results"
-_check_count "$app_name1.*|" 1 "$test_results"
+_check_count "$app_name1.*|" 2 "$test_results"
 
 # Test hide for another app
 _log "Test unhide $app_name2..."

--- a/regress/test-am-regress.sh
+++ b/regress/test-am-regress.sh
@@ -18,6 +18,7 @@ _log "Done.\n"
 ./test-am-repair.sh
 ./test-am-sandbox.sh
 ./test-am-nolibfuse.sh
+./test-am-rollback.sh
 
 # Done
 _log "Regression testing complete:"

--- a/regress/test-am-rollback.sh
+++ b/regress/test-am-rollback.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+
+# Source common test functions
+. "$(dirname "$0")/test-common.sh"
+
+# Test variables
+test_results=".results.tmp"
+app_name1=$(_pick_random_app "$TEST_APP_LIST_DOWN")
+
+## Setup
+_log "Running version rollback test: $0"
+am --system
+am -R "$app_name1"
+
+# Install app
+_log "Installing $app_name1..."
+am -i "$app_name1"
+am -f > "$test_results"
+_check_count "$app_name1.*|" 1 "$test_results"
+app_ver_latest="$(_get_app_info "$app_name1" 2)"
+
+# Test rollback
+_log "Test rollback $app_name1..."
+printf "y\n2\n" |\
+am downgrade "$app_name1"
+app_ver_old="$(_get_app_info "$app_name1" 2)"
+[ "$app_ver_old" = "$app_ver_latest" ] && _fail "Error: \"$app_name1\" version rollback failed"
+
+# Test lock
+_log "Test lock $app_name1..."
+printf "y\n" |\
+am lock "$app_name1"
+app_ver_old_locked="$(_get_app_info "$app_name1" 2)"
+[ "$app_ver_old_locked" = "$app_ver_old" ] && _fail "Error: \"$app_name1\" version lock failed"
+
+# Try to update locked app
+_log "Test update locked $app_name1..."
+am -u "$app_name1" > "$test_results"
+_check_count "cannot be updated" 1 "$test_results"
+app_ver_old_updated="$(_get_app_info "$app_name1" 2)"
+[ "$app_ver_old_updated" = "$app_ver_latest" ] && _fail "Error: \"$app_name1\" version updated despite locked status"
+
+# Test unlock
+_log "Test unlock $app_name1..."
+printf "y\n" |\
+am unlock "$app_name1"
+app_ver_old_unlocked="$(_get_app_info "$app_name1" 2)"
+[ "$app_ver_old_unlocked" != "$app_ver_old" ] && _fail "Error: \"$app_name1\" version unlock failed"
+
+# Update unlocked app
+_log "Test update unlocked $app_name1..."
+am -u "$app_name1" > "$test_results"
+_check_count "cannot be updated" 0 "$test_results"
+app_ver_old_updated="$(_get_app_info "$app_name1" 2)"
+[ "$app_ver_old_updated" != "$app_ver_latest" ] && _fail "Error: \"$app_name1\" version cannot be updated despite unlocked status"
+
+# Pass the test
+_remove_all_apps
+_pass
+

--- a/regress/test-common.sh
+++ b/regress/test-common.sh
@@ -18,6 +18,9 @@ TEST_APP_LIST_NOCHK="bench-cli helio appimagen appimageupdate crabfetch colorsta
 # List of test apps that are outdated (REQUIREMENTS: Under 10MB, simple install script)
 TEST_APP_LIST_OLD="aisap bench-cli colorstatic-bash fcp"
 
+# List of test apps that can be downgraded (REQUIREMENTS: Under 5MB, simple install script)
+TEST_APP_LIST_DOWN="clifm aisap fcp zsync2"
+
 # Function to randomly pick an app from a list
 _pick_random_app() {
 	# Get count
@@ -51,7 +54,7 @@ _remove_item() {
 		fi
 	done
 
-	# Output both picked item and new list
+	# Output new list with item removed
 	echo "$new_list"
 }
 
@@ -109,6 +112,14 @@ _remove_all_apps() {
 	if [ "$(am -f --less | sed -n 3p)" != "0" ]; then
 		_fail "Error: Unable to fully remove AM local apps."
 	fi
+}
+
+# Function to get app info from am -f table collumns
+_get_app_info() {
+	app_name="$1"
+	info_collumn="$2"
+	app_info=$(am -f | grep "$app_name" | cut -d'|' -f"$info_collumn" | head -n 1)
+	echo "$app_info"
 }
 
 # Function to check the count of a specific message/text in the results


### PR DESCRIPTION
Updates:
- Added app rollback and version lock test.
- Added new rollback test to main regression list.
- Improved hide/unhide test to check locally installed apps.
- Disable AM notifications in containers by default.

Hi @ivan-hc, I think I found a bug. The rollback function does not list snapshots/backups of an app. Have you tested this feature?