### PR TITLE
fix(APP-MANAGER): `warning: command substitution: ignored null byte in input`

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1553,7 +1553,7 @@ _use_verify() {
 		fi
 		if [ -n "$download_url" ]; then
 			# Search for zsync file
-			digest=$(curl -Lsf "$download_url.zsync" | grep -a "SHA\|MD5")
+			digest=$(curl -Lsf "$download_url.zsync" | grep -a "SHA\|MD5" | tr -d '\0')
 			if [ -z "$digest" ]; then
 				# Search other sources if no zsync file
 				for ext in digest DIGEST sha512 sha256 sha1 md5; do


### PR DESCRIPTION
This happens during updating apps, when `digest` variable is set from `zsync` file.

Bash cannot store null bytes in variables, so it shows this warning message.

Fix this issue by trimming the null byte in `digest` variable.