### PR TITLE
Show update version changes in a table

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1640,6 +1640,43 @@ _update_list_updatable_apps() {
 	fi
 }
 
+_update_print_updated_apps_table() {
+	OLDVER="$1"
+	NEWVER="$2"
+	diff "$OLDVER" "$NEWVER" | grep "^>" | sed 's/^> //g' | while IFS= read -r updated_app; do
+		arg=$(printf "%s\n" "$updated_app" | awk '{print $2}')
+		old_app=$(grep -F " ◆ $arg " "$OLDVER" | head -1)
+		old_version=$(printf "%s\n" "$old_app" | sed "s/^ ◆ $arg //; s/\x1b\[[0-9;]*m//g; s/[✖✓🔒]//g; s/  */ /g; s/ $//")
+		new_version=$(printf "%s\n" "$updated_app" | sed "s/^ ◆ $arg //; s/\x1b\[[0-9;]*m//g; s/[✖✓🔒]//g; s/  */ /g; s/ $//")
+		printf "%s\t%s\t%s\n" "$arg" "$old_version" "$new_version"
+	done | awk -F '\t' -v blue="$LightBlue" -v reset="\033[0m" '
+		BEGIN {
+			app_header = "App"
+			old_header = "Previous"
+			new_header = "Current"
+			app_width = length(app_header)
+			old_width = length(old_header)
+			new_width = length(new_header)
+		}
+		{
+			apps[NR] = $1
+			old_versions[NR] = $2
+			new_versions[NR] = $3
+			if (length($1) > app_width) app_width = length($1)
+			if (length($2) > old_width) old_width = length($2)
+			if (length($3) > new_width) new_width = length($3)
+		}
+		END {
+			header_format = "     %s%-" app_width "s%s  %s%-" old_width "s%s  %s%-" new_width "s%s\n"
+			row_format = "%2d.  %-" app_width "s  %-" old_width "s  %-" new_width "s\n"
+			printf header_format, blue, app_header, reset, blue, old_header, reset, blue, new_header, reset
+			for (i = 1; i <= NR; i++) {
+				printf row_format, i, apps[i], old_versions[i], new_versions[i]
+			}
+		}
+	'
+}
+
 _update_determine_apps_version_changes() {
 	[ -z "$debug_update" ] && echo "$DIVIDING_LINE"
 	if [ -f "$AMCACHEDIR"/updatable-args-list ]; then
@@ -1651,7 +1688,7 @@ _update_determine_apps_version_changes() {
 			printf $" Nothing to do here! \n"
 		else
 			printf $" The following apps have been updated:\n\n"
-			diff "$OLDVER" "$NEWVER" | grep "^>" | sed 's/^> //g' | sed 's/\([✖✓🔒]\)/ \1/g'
+			_update_print_updated_apps_table "$OLDVER" "$NEWVER"
 			echo ""
 		fi
 	else


### PR DESCRIPTION
Improve the update summary output by showing version transitions in a readable table.
Previously, after running updates, the final summary only showed the new detected version:

```text
◆ shotcut 26.4.30
```

This made it hard to tell what actually changed, especially when updating several apps at once. The new output shows both the previous and current version:

<img width="806" height="502" alt="Screenshot_20260501_101035" src="https://github.com/user-attachments/assets/b097eea9-1e14-42a2-8269-62926a89b29e" />


---
I was inspired by Flatpak’s update table:)

<img width="928" height="115" alt="image" src="https://github.com/user-attachments/assets/8673f006-0226-4c96-bd50-d04ff2c0bcb4" />
