### PR TITLE
Fix untranslatable strings

### DIFF
--- a/AM-INSTALLER
+++ b/AM-INSTALLER
@@ -43,7 +43,7 @@ _install_am() {
 	elif command -v doas >/dev/null 2>&1; then
 		SUDOCMD="doas"
 	else
-		echo 'ERROR: No sudo or doas found'
+		echo $"ERROR: No sudo or doas found"
 		exit 1
 	fi
 	$SUDOCMD "$CACHEDIR"/INSTALL-AM.sh && rm -f "$CACHEDIR"/INSTALL-AM.sh

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -331,7 +331,7 @@ _am() {
 	elif command -v doas >/dev/null 2>&1; then
 		export SUDOCMD="doas"
 	else
-		echo $'ERROR: No sudo or doas found'
+		echo $"ERROR: No sudo or doas found"
 		exit 1
 	fi
 	APPSPATH="$(readlink -f /opt)"
@@ -1176,7 +1176,7 @@ _clean_launchers() {
 		fi
 		[ -z "$mountpoint_enabled" ] && [ -n "$BINDIR" ] && cd "$BINDIR" && find . -xtype l -delete
 		rm -f "$AMCACHEDIR"/mountpoints
-		echo $' ✔ Removed orphaned launchers produced with the "--launcher" option'
+		echo $" ✔ Removed orphaned launchers produced with the \"--launcher\" option"
 		rmdir "$DATADIR"/"$LAUNCHERS_DIR"/AppImages
 	else
 		[ -n "$BINDIR" ] && cd "$BINDIR" && find . -xtype l -delete
@@ -1692,7 +1692,7 @@ _update_determine_apps_version_changes() {
 			echo ""
 		fi
 	else
-		echo $' No apps to update here!'
+		echo $" No apps to update here!"
 	fi
 }
 

--- a/modules/database.am
+++ b/modules/database.am
@@ -584,15 +584,15 @@ _files_notify_archived_and_obsolete_apps() {
 _files_total_size() {
 	printf "\n"
 	if command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files* && [ -n "$APPLOCKED" ]; then
-		printf $'%s\n\n' " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+		printf $'%s\n\n' $" AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
 	elif command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files*; then
-		printf $'%s\n\n' " AppImages with 🔒 are sandboxed with aisap"
+		printf $'%s\n\n' $" AppImages with 🔒 are sandboxed with aisap"
 	elif command -v sas >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files* && [ -n "$APPLOCKED" ]; then
-		printf $'%s\n\n' " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+		printf $'%s\n\n' $" AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
 	elif command -v sas >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files*; then
-		printf $'%s\n\n' " AppImages with 🔒 are sandboxed with sas"
+		printf $'%s\n\n' $" AppImages with 🔒 are sandboxed with sas"
 	elif [ -n "$APPLOCKED" ]; then
-		printf $'%s\n\n' " Versions with 🔒 are locked"
+		printf $'%s\n\n' $" Versions with 🔒 are locked"
 	fi
 	APPLOCKED=""
 	INSTALLED_APPS_PLAN=$(echo "$INSTALLED_APPS_PATHS" | xargs)

--- a/modules/install.am
+++ b/modules/install.am
@@ -32,7 +32,7 @@ _convert_to_appman_compatible_script() {
 		printf $" Converting %s to an AppMan-compatible script.\r" "$arg" && sleep 0.25 &&
 		printf "                                                                           \r"
 	else
-		echo $' 💀 ERROR: "--convert" requires a configuration file in ~/.config/appman'
+		echo $" 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
 	fi
 }
 

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -64,8 +64,8 @@ _check_aisap() {
 		echo $" Error: You can't sandbox $1"
 		return 1
 	elif ! command -v aisap 1>/dev/null && ! command -v sas 1>/dev/null; then
-		printf $'\n%s\n' " ERROR: You need aisap or sas for this script to work"
-		printf $'\n%s\n\n' " NOTE: Only sas can sandbox DWARFS AppImages"
+		printf $'\n%s\n' $" ERROR: You need aisap or sas for this script to work"
+		printf $'\n%s\n\n' $" NOTE: Only sas can sandbox DWARFS AppImages"
 		read -r -p $" ◆ DO YOU WISH TO INSTALL SAS? Install size <5 MiB? (Y/n) " yn
 		case "$yn" in
 			n*|N*) echo $" OPERATION ABORTED!"; return 1;;
@@ -226,7 +226,7 @@ _configure_dirs_access() {
 	if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 		echo $"  WARNING: Giving access to all of $HOME or / and similar is not safe"
 		echo $"  Also aisap might not let $1 start when such paths are given"
-		printf $'\033[33m%s\n' "  Type the path to the directory"
+		printf $'\033[33m%s\n' $"  Type the path to the directory"
 		read -r -p $"  Example: /media/external-drive or ~/Backups: " NEWDIR
 		NEWDIR="$(readlink -f "$NEWDIR")"
 		case "$NEWDIR" in
@@ -237,7 +237,7 @@ _configure_dirs_access() {
 				[ "$YES" != "YES" ] && echo $" That's not \"YES\", aborting" && return 1
 				;;
 			'')
-				printf $'\033[31m\n%s\n\n' " No path given, aborting"
+				printf $'\033[31m\n%s\n\n' $" No path given, aborting"
 				return 1
 				;;
 		esac
@@ -245,7 +245,7 @@ _configure_dirs_access() {
 		tmpscript=$(echo "$tmpscript" \
 			| sed "s#--rm-file /NOPATH#--add-file \"$NEWDIR\":rw#g")
 	fi
-	printf $'\n\033[32m%s\n' " User directories access configured successfully!"
+	printf $'\n\033[32m%s\n' $" User directories access configured successfully!"
 }
 
 _install_sandbox_script() {

--- a/modules/template.am
+++ b/modules/template.am
@@ -108,7 +108,7 @@ _edit_script_ending() {
 
 _template_custom_download_url_as_version_variable() {
 	# IF YOU CAN, USE A ONE-LINE COMMAND TO DOWNLOAD THE PROGRAM
-	read -r -ep " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION $(echo -e $'\n\n if the URL is fixed, simply add the "echo" command at the beginning\n\n :') " DOWNLOADURL
+	read -r -ep "$(printf $" USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :") " DOWNLOADURL
 	case "$DOWNLOADURL" in
 	*)
 		_edit_script_head
@@ -289,11 +289,11 @@ _template_test_github_alt_architectures_url() {
 _template_then_git_repo() {
 	_template_if_git_repo
 	# Set the release as "latest" or keep it generic
-	read -r -p $' Latest release (y) or a generic one (N or leave blank)?' yn
+	read -r -p $" Latest release (y) or a generic one (N or leave blank)?" yn
 	if echo "$yn" | grep -qi "^y"; then
 		warn_about_latest_releases_choice="ARE YOU SURE??? The original project might omit Linux builds from the \"latest\" release section in the future! You might not be able to get any builds at all! Think carefully! Consider using keywords for \"grep\" in the next steps."
 		printf "\n%b%b\033[0m\n\n" "${RED}" "$warn_about_latest_releases_choice" | _fit
-		read -r -p $' Latest release (y) or a generic one (N or leave blank)?' yn
+		read -r -p $" Latest release (y) or a generic one (N or leave blank)?" yn
 		if echo "$yn" | grep -qi "^y"; then
 			setlatest="/latest"
 			sed -i 's#/releases #/releases/latest #g' ./am-scripts/"$MAIN_ARCH"/"$arg"
@@ -305,7 +305,7 @@ _template_then_git_repo() {
 	fi
 	echo "$DIVIDING_LINE"
 	# Check if the URL is correct
-	read -r -p $' Do you wish to check the link (Y,n)?' yn
+	read -r -p $" Do you wish to check the link (Y,n)?" yn
 	if ! echo "$yn" | grep -qi "^n"; then
 		if [ "$templatetype" = 0 ] || [ -z "$templatetype" ]; then
 			GHURLPREVIEW_COMMAND="$CURL_COMMAND_REF_PREVIEW/$RESPONSE/releases$setlatest | sed 's/[()\",{} ]/\n/g' | grep -oi \"https.*download.*mage$\" | grep -vi \"i386\|i686\|armhf\|aarch64\|arm64\|armv7l\" | head -1"
@@ -318,13 +318,13 @@ _template_then_git_repo() {
 	fi
 	echo "$DIVIDING_LINE"
 	# Add/remove keywords or leave blank to skip
-	read -r -p $' If correct, press "ENTER", 1 to add keywords and 2 to remove keywords: ' response
+	read -r -p $" If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: " response
 	case "$response" in
 	1)
-		read -r -ep $' URL must contain ("x64", "x86_64"... or leave blank): ' response
+		read -r -ep $" URL must contain (\"x64\", \"x86_64\"... or leave blank): " response
 		if [ -n "$response" ]; then
 			sed -i "s# head -1# grep -i \"$response\" | head -1#g" ./am-scripts/"$MAIN_ARCH"/"$arg"
-			read -r -p $' Do you wish to check the link for the last time (Y,n)?' yn
+			read -r -p $" Do you wish to check the link for the last time (Y,n)?" yn
 			if ! echo "$yn" | grep -qi "^n"; then
 				if [ "$templatetype" = 0 ] || [ -z "$templatetype" ]; then
 					GHURLPREVIEW_COMMAND="$CURL_COMMAND_REF_PREVIEW/$RESPONSE/releases$setlatest | sed 's/[()\",{} ]/\n/g' | grep -oi \"https.*download.*mage$\" | grep -vi \"i386\|i686\|armhf\|aarch64\|arm64\|armv7l\" | grep -i \"$response\" | head -1"
@@ -338,10 +338,10 @@ _template_then_git_repo() {
 		fi
 		;;
 	2)
-		read -r -ep $' URL must NOT contain ("txt", "ARM"... or leave blank): ' response
+		read -r -ep $" URL must NOT contain (\"txt\", \"ARM\"... or leave blank): " response
 		if [ -n "$response" ]; then
 			sed -i "s# head -1# grep -v \"$response\" | head -1#g" ./am-scripts/"$MAIN_ARCH"/"$arg"
-			read -r -p $' Do you wish to check the link for the last time (Y,n)?' yn
+			read -r -p $" Do you wish to check the link for the last time (Y,n)?" yn
 			if ! echo "$yn" | grep -qi "^n"; then
 				if [ "$templatetype" = 0 ] || [ -z "$templatetype" ]; then
 					GHURLPREVIEW_COMMAND="$CURL_COMMAND_REF_PREVIEW/$RESPONSE/releases$setlatest | sed 's/[()\",{} ]/\n/g' | grep -oi \"https.*download.*mage$\" | grep -vi \"i386\|i686\|armhf\|aarch64\|arm64\|armv7l\" | grep -v \"$response\" | head -1"
@@ -552,7 +552,7 @@ for arg in $ARGS; do
 				esac
 				echo "$DIVIDING_LINE"
 				# APPNAME
-				read -r -ep $' ◆ NAME OF THE APP (for the "Name" entry of the .desktop file): ' APPNAME
+				read -r -ep $" ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): " APPNAME
 				case "$APPNAME" in
 				*)
 					sed -i "s#APPNAME#$APPNAME#g" ./am-scripts/"$MAIN_ARCH"/"$arg"

--- a/translations/po-files/cs.po
+++ b/translations/po-files/cs.po
@@ -619,6 +619,10 @@ msgstr " Zde není co dělat! \\n"
 msgid " The following apps have been updated:\\n\\n"
 msgstr " Následující aplikace byly aktualizovány:\\n\\n"
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr " Žádné aplikace k aktualizaci!"
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr " %b✔\\033[0m $APPNAME aktuální, $timelapsed vteřin uplynulo! \\n"
@@ -2061,3 +2065,86 @@ msgstr "\\n Nevybrán validní argument: proces přerušen! \\n"
 
 #~ msgid "%b%b"
 #~ msgstr "%b%b"
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr "CHYBA: sudo ani doas nebylo nalezeno"
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr " ✔ Odstraněny osiřelé spouštěče vytvořené volbou \"--launcher\""
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr " 💀 CHYBA: \"--convert\" vyžaduje konfigurační soubor v ~/.config/appman"
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr " CHYBA: Pro fungování tohoto skriptu potřebujete aisap nebo sas"
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr " POZNÁMKA: Pouze sas umí sandboxovat DWARFS AppImage"
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr "  Zadejte cestu k adresáři"
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr " Nebyla zadána cesta, ruším"
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr " Přístup k uživatelským adresářům byl úspěšně nastaven!"
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr " AppImage s 🔒 jsou sandboxovány pomocí aisap, verze s 🔒 jsou uzamčeny"
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr " AppImage s 🔒 jsou sandboxovány pomocí aisap"
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr " AppImage s 🔒 jsou sandboxovány pomocí sas, verze s 🔒 jsou uzamčeny"
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr " AppImage s 🔒 jsou sandboxovány pomocí sas"
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr " Verze s 🔒 jsou uzamčeny"
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr " Nejnovější vydání (y) nebo obecné (N nebo prázdné)?"
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr " Chcete zkontrolovat odkaz (Y,n)?"
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr " Pokud je správně, stiskněte \"ENTER\", 1 pro přidání klíčových slov a 2 pro odebrání: "
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr " URL musí obsahovat (\"x64\", \"x86_64\"... nebo ponechte prázdné): "
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr " Chcete odkaz zkontrolovat naposledy (Y,n)?"
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr " URL NESMÍ obsahovat (\"txt\", \"ARM\"... nebo ponechte prázdné): "
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr " ◆ NÁZEV APLIKACE (pro položku \"Name\" v souboru .desktop): "
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr " POUŽIJTE JEDNOŘÁDKOVÝ PŘÍKAZ PRO KONTROLU URL PROGRAMU NEBO VERZE\n\n pokud je URL pevná, jednoduše přidejte příkaz \"echo\" na začátek\n\n :"

--- a/translations/po-files/de.po
+++ b/translations/po-files/de.po
@@ -667,6 +667,10 @@ msgstr " Nichts zu tun! \\n"
 msgid " The following apps have been updated:\\n\\n"
 msgstr " Die folgenden Apps wurden aktualisiert:\\n\\n"
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr " Keine Apps zum Aktualisieren vorhanden!"
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr ""
@@ -2290,3 +2294,86 @@ msgstr "\\n Kein gültiges Argument gewählt: Vorgang abgebrochen! \\n"
 
 #~ msgid "%b%b"
 #~ msgstr "%b%b"
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr "FEHLER: sudo oder doas nicht gefunden"
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr " ✔ Verwaiste Starter entfernt, die mit der Option \"--launcher\" erstellt wurden"
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr " 💀 FEHLER: \"--convert\" benötigt eine Konfigurationsdatei in ~/.config/appman"
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr " FEHLER: Für dieses Skript wird aisap oder sas benötigt"
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr " HINWEIS: Nur sas kann DWARFS-AppImages in eine Sandbox verschieben"
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr "  Pfad zum Verzeichnis eingeben"
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr " Kein Pfad angegeben, Abbruch"
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr " Zugriff auf Benutzerverzeichnisse erfolgreich konfiguriert!"
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr " AppImages mit 🔒 sind mit aisap sandboxed, Versionen mit 🔒 sind gesperrt"
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr " AppImages mit 🔒 sind mit aisap sandboxed"
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr " AppImages mit 🔒 sind mit sas sandboxed, Versionen mit 🔒 sind gesperrt"
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr " AppImages mit 🔒 sind mit sas sandboxed"
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr " Versionen mit 🔒 sind gesperrt"
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr " Neueste Veröffentlichung (y) oder generisch (N oder leer lassen)?"
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr " Link prüfen (Y,n)?"
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr " Wenn korrekt, \"ENTER\" drücken, 1 zum Hinzufügen und 2 zum Entfernen von Schlüsselwörtern: "
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr " URL muss enthalten (\"x64\", \"x86_64\"... oder leer lassen): "
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr " Link ein letztes Mal prüfen (Y,n)?"
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr " URL darf NICHT enthalten (\"txt\", \"ARM\"... oder leer lassen): "
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr " ◆ NAME DER APP (für den Eintrag \"Name\" in der .desktop-Datei): "
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr " VERWENDEN SIE EINEN EINZEILIGEN BEFEHL, UM DIE URL DES PROGRAMMS ODER DIE VERSION ZU PRÜFEN\n\n wenn die URL fest ist, fügen Sie einfach den Befehl \"echo\" am Anfang hinzu\n\n :"

--- a/translations/po-files/es.po
+++ b/translations/po-files/es.po
@@ -636,6 +636,10 @@ msgstr " Nada para hacer aquí! \\n"
 msgid " The following apps have been updated:\\n\\n"
 msgstr " Las siguientes aplicaciones han sido actualizadas:\\n\\n"
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr " ¡No hay aplicaciones para actualizar!"
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr ""
@@ -2100,3 +2104,86 @@ msgstr "\\n No se eligió ningún argumento válido: ¡proceso abortado! \\n"
 
 #~ msgid "%b%b"
 #~ msgstr "%b%b"
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr "ERROR: no se encontró sudo ni doas"
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr " ✔ Eliminados lanzadores huérfanos creados con la opción \"--launcher\""
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr " 💀 ERROR: \"--convert\" requiere un archivo de configuración en ~/.config/appman"
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr " ERROR: necesita aisap o sas para que este script funcione"
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr " NOTA: solo sas puede aislar AppImages DWARFS"
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr "  Escriba la ruta al directorio"
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr " No se indicó ninguna ruta, abortando"
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr " ¡Acceso a directorios de usuario configurado correctamente!"
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr " AppImages con 🔒 están aisladas con aisap, versiones con 🔒 están bloqueadas"
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr " AppImages con 🔒 están aisladas con aisap"
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr " AppImages con 🔒 están aisladas con sas, versiones con 🔒 están bloqueadas"
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr " AppImages con 🔒 están aisladas con sas"
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr " Las versiones con 🔒 están bloqueadas"
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr " ¿Última versión (y) o genérica (N o dejar en blanco)?"
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr " ¿Desea comprobar el enlace (Y,n)?"
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr " Si es correcto, pulse \"ENTER\", 1 para añadir palabras clave y 2 para eliminarlas: "
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr " La URL debe contener (\"x64\", \"x86_64\"... o dejar en blanco): "
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr " ¿Desea comprobar el enlace por última vez (Y,n)?"
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr " La URL NO debe contener (\"txt\", \"ARM\"... o dejar en blanco): "
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr " ◆ NOMBRE DE LA APP (para la entrada \"Name\" del archivo .desktop): "
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr " USE UN COMANDO DE UNA LÍNEA PARA COMPROBAR LA URL DEL PROGRAMA O LA VERSIÓN\n\n si la URL es fija, simplemente añada el comando \"echo\" al principio\n\n :"

--- a/translations/po-files/it.po
+++ b/translations/po-files/it.po
@@ -647,6 +647,10 @@ msgstr " È tutto a posto! \\n"
 msgid " The following apps have been updated:\\n\\n"
 msgstr " Le seguenti app sono state aggiornate:\\n\\n"
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr " Nessuna app da aggiornare!"
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr " %b✔\\033[0m $APPNAME è aggiornato, $timelapsed secondo trascorso! \\n"
@@ -2310,3 +2314,86 @@ msgstr ""
 
 #~ msgid "Checksum matches, verification successful."
 #~ msgstr "Il checksum corrisponde, verifica riuscita."
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr "ERRORE: sudo o doas non trovato"
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr " ✔ Rimossi i launcher orfani creati con l'opzione \"--launcher\""
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr " 💀 ERRORE: \"--convert\" richiede un file di configurazione in ~/.config/appman"
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr " ERRORE: serve aisap o sas perché questo script funzioni"
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr " NOTA: solo sas può isolare in sandbox le AppImage DWARFS"
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr "  Digita il percorso della directory"
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr " Nessun percorso indicato, annullo"
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr " Accesso alle directory utente configurato correttamente!"
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr " Le AppImage con 🔒 sono in sandbox con aisap, le versioni con 🔒 sono bloccate"
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr " Le AppImage con 🔒 sono in sandbox con aisap"
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr " Le AppImage con 🔒 sono in sandbox con sas, le versioni con 🔒 sono bloccate"
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr " Le AppImage con 🔒 sono in sandbox con sas"
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr " Le versioni con 🔒 sono bloccate"
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr " Ultima release (y) o generica (N o lascia vuoto)?"
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr " Vuoi controllare il link (Y,n)?"
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr " Se corretto, premi \"ENTER\", 1 per aggiungere keyword e 2 per rimuoverle: "
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr " L'URL deve contenere (\"x64\", \"x86_64\"... o lascia vuoto): "
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr " Vuoi controllare il link un'ultima volta (Y,n)?"
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr " L'URL NON deve contenere (\"txt\", \"ARM\"... o lascia vuoto): "
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr " ◆ NOME DELL'APP (per la voce \"Name\" del file .desktop): "
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr " USA UN COMANDO SU UNA SOLA RIGA PER CONTROLLARE L'URL DEL PROGRAMMA O LA VERSIONE\n\n se l'URL è fisso, aggiungi semplicemente il comando \"echo\" all'inizio\n\n :"

--- a/translations/po-files/pt_BR.po
+++ b/translations/po-files/pt_BR.po
@@ -657,6 +657,10 @@ msgstr " Nada para fazer aqui! \\n"
 msgid " The following apps have been updated:\\n\\n"
 msgstr " Os seguintes apps foram atualizados:\\n\\n"
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr " Nenhum app para atualizar!"
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr ""
@@ -2299,3 +2303,86 @@ msgstr "\\n Nenhum argumento válido foi escolhido: processo abortado! \\n"
 
 #~ msgid "✔ $APPMAN_APPSPATH/$arg can be managed again"
 #~ msgstr "✔ $APPMAN_APPSPATH/$arg pode ser gerenciado novamente"
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr "ERRO: sudo ou doas não encontrado"
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr " ✔ Lançadores órfãos criados com a opção \"--launcher\" foram removidos"
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr " 💀 ERRO: \"--convert\" requer um arquivo de configuração em ~/.config/appman"
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr " ERRO: você precisa do aisap ou sas para este script funcionar"
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr " NOTA: apenas o sas pode colocar AppImages DWARFS em sandbox"
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr "  Digite o caminho para o diretório"
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr " Nenhum caminho informado, abortando"
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr " Acesso aos diretórios do usuário configurado com sucesso!"
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr " AppImages com 🔒 estão em sandbox com aisap, versões com 🔒 estão bloqueadas"
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr " AppImages com 🔒 estão em sandbox com aisap"
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr " AppImages com 🔒 estão em sandbox com sas, versões com 🔒 estão bloqueadas"
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr " AppImages com 🔒 estão em sandbox com sas"
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr " Versões com 🔒 estão bloqueadas"
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr " Última versão (y) ou genérica (N ou deixe em branco)?"
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr " Deseja verificar o link (Y,n)?"
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr " Se estiver correto, pressione \"ENTER\", 1 para adicionar palavras-chave e 2 para remover: "
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr " A URL deve conter (\"x64\", \"x86_64\"... ou deixe em branco): "
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr " Deseja verificar o link pela última vez (Y,n)?"
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr " A URL NÃO deve conter (\"txt\", \"ARM\"... ou deixe em branco): "
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr " ◆ NOME DO APP (para a entrada \"Name\" do arquivo .desktop): "
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr " USE UM COMANDO DE UMA LINHA PARA VERIFICAR A URL DO PROGRAMA OU A VERSÃO\n\n se a URL for fixa, basta adicionar o comando \"echo\" no início\n\n :"

--- a/translations/po-files/ru.po
+++ b/translations/po-files/ru.po
@@ -656,6 +656,10 @@ msgid " The following apps have been updated:\\n\\n"
 msgstr ""
 " Следующие приложения были обновлены:\\n\\n"
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr " Нет приложений для обновления!"
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr ""
@@ -2305,3 +2309,86 @@ msgstr " ◆ URL WEBAPP: "
 msgid "\\n No valid argument was chosen: process aborted! \\n"
 msgstr ""
 "\\n Подходящий аргумент не выбран: действие отменено! \\n"
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr "ОШИБКА: sudo или doas не найдены"
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr " ✔ Удалены осиротевшие ярлыки, созданные опцией \"--launcher\""
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr " 💀 ОШИБКА: для \"--convert\" нужен файл конфигурации в ~/.config/appman"
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr " ОШИБКА: для работы этого скрипта нужен aisap или sas"
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr " ПРИМЕЧАНИЕ: только sas умеет помещать DWARFS AppImage в песочницу"
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr "  Укажите путь к папке"
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr " Путь не указан, отмена"
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr " Доступ к пользовательским папкам настроен!"
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr " AppImage с 🔒 запущены через aisap, версии с 🔒 заблокированы"
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr " AppImage с 🔒 запущены через aisap"
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr " AppImage с 🔒 запущены через sas, версии с 🔒 заблокированы"
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr " AppImage с 🔒 запущены через sas"
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr " Версии с 🔒 заблокированы"
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr " Последний релиз (y) или общий вариант (N или пусто)?"
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr " Проверить ссылку (Y,n)?"
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr " Если всё верно, нажмите \"ENTER\"; 1 — добавить ключевые слова, 2 — удалить: "
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr " URL должен содержать (\"x64\", \"x86_64\"... или оставьте пустым): "
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr " Проверить ссылку ещё раз (Y,n)?"
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr " URL НЕ должен содержать (\"txt\", \"ARM\"... или оставьте пустым): "
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr " ◆ ИМЯ ПРИЛОЖЕНИЯ (для поля \"Name\" в .desktop-файле): "
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr " ИСПОЛЬЗУЙТЕ ОДНОСТРОЧНУЮ КОМАНДУ ДЛЯ ПРОВЕРКИ URL ПРОГРАММЫ ИЛИ ВЕРСИИ\n\n если URL фиксированный, просто добавьте команду \"echo\" в начало\n\n :"

--- a/translations/po-files/sr.po
+++ b/translations/po-files/sr.po
@@ -645,6 +645,10 @@ msgstr " Ovde nema ništa da se radi! \\n"
 msgid " The following apps have been updated:\\n\\n"
 msgstr " Sledeće aplikacije su ažurirane:\\n\\n"
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr " Nema aplikacija za ažuriranje!"
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr " %b✔\\033[0m $APPNAME je ažuriran, $timelapsed sekund je prošao! \\n"
@@ -2285,3 +2289,86 @@ msgstr "\\n Nijedan važeći argument nije odabran: proces obustavljen! \\n"
 
 #~ msgid "%b%b"
 #~ msgstr "%b%b"
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr "GREŠKA: sudo ili doas nisu pronađeni"
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr " ✔ Uklonjeni su napušteni pokretači napravljeni opcijom \"--launcher\""
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr " 💀 GREŠKA: \"--convert\" zahteva konfiguracioni fajl u ~/.config/appman"
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr " GREŠKA: potreban je aisap ili sas da bi ova skripta radila"
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr " NAPOMENA: samo sas može da sandboxuje DWARFS AppImage-ove"
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr "  Unesi putanju do direktorijuma"
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr " Putanja nije data, prekidam"
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr " Pristup korisničkim direktorijumima je uspešno podešen!"
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr " AppImage-ovi sa 🔒 su sandboxovani pomoću aisap, verzije sa 🔒 su zaključane"
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr " AppImage-ovi sa 🔒 su sandboxovani pomoću aisap"
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr " AppImage-ovi sa 🔒 su sandboxovani pomoću sas, verzije sa 🔒 su zaključane"
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr " AppImage-ovi sa 🔒 su sandboxovani pomoću sas"
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr " Verzije sa 🔒 su zaključane"
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr " Najnovije izdanje (y) ili generičko (N ili prazno)?"
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr " Želiš li da proveriš link (Y,n)?"
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr " Ako je ispravno, pritisni \"ENTER\", 1 za dodavanje ključnih reči i 2 za uklanjanje: "
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr " URL mora da sadrži (\"x64\", \"x86_64\"... ili ostavi prazno): "
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr " Želiš li poslednji put da proveriš link (Y,n)?"
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr " URL NE sme da sadrži (\"txt\", \"ARM\"... ili ostavi prazno): "
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr " ◆ IME APLIKACIJE (za \"Name\" unos u .desktop fajlu): "
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr " KORISTI JEDNOLINIJSKU KOMANDU ZA PROVERU URL-A PROGRAMA ILI VERZIJE\n\n ako je URL fiksan, jednostavno dodaj komandu \"echo\" na početak\n\n :"

--- a/translations/source.po
+++ b/translations/source.po
@@ -567,6 +567,10 @@ msgstr ""
 msgid " The following apps have been updated:\\n\\n"
 msgstr ""
 
+#: APP-MANAGER:1695
+msgid " No apps to update here!"
+msgstr ""
+
 #: APP-MANAGER:1737
 msgid " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr ""
@@ -1926,4 +1930,87 @@ msgstr ""
 
 #: modules/template.am:611
 msgid "\\n No valid argument was chosen: process aborted! \\n"
+msgstr ""
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr ""
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr ""
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr ""
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr ""
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr ""
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr ""
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr ""
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr ""
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr ""
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr ""
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr ""
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr ""
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr ""
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr ""
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr ""
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr ""
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr ""
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr ""
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr ""
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr ""
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
 msgstr ""

--- a/translations/source.pot
+++ b/translations/source.pot
@@ -514,6 +514,10 @@ msgstr  ""
 msgid   " The following apps have been updated:\\n\\n"
 msgstr  ""
 
+#: APP-MANAGER:1695
+msgid   " No apps to update here!"
+msgstr  ""
+
 #: APP-MANAGER:1737
 msgid   " %b✔\\033[0m $APPNAME is updated, $timelapsed second elapsed! \\n"
 msgstr  ""
@@ -1685,3 +1689,86 @@ msgstr  ""
 #: modules/template.am:611
 msgid   "\\n No valid argument was chosen: process aborted! \\n"
 msgstr  ""
+
+#: APP-MANAGER:334
+msgid "ERROR: No sudo or doas found"
+msgstr ""
+
+#: APP-MANAGER:1179
+msgid " ✔ Removed orphaned launchers produced with the \"--launcher\" option"
+msgstr ""
+
+#: modules/install.am:35
+msgid " 💀 ERROR: \"--convert\" requires a configuration file in ~/.config/appman"
+msgstr ""
+
+#: modules/sandboxes.am:67
+msgid " ERROR: You need aisap or sas for this script to work"
+msgstr ""
+
+#: modules/sandboxes.am:68
+msgid " NOTE: Only sas can sandbox DWARFS AppImages"
+msgstr ""
+
+#: modules/sandboxes.am:229
+msgid "  Type the path to the directory"
+msgstr ""
+
+#: modules/sandboxes.am:240
+msgid " No path given, aborting"
+msgstr ""
+
+#: modules/sandboxes.am:248
+msgid " User directories access configured successfully!"
+msgstr ""
+
+#: modules/database.am:587
+msgid " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+msgstr ""
+
+#: modules/database.am:589
+msgid " AppImages with 🔒 are sandboxed with aisap"
+msgstr ""
+
+#: modules/database.am:591
+msgid " AppImages with 🔒 are sandboxed with sas, versions with 🔒 are locked"
+msgstr ""
+
+#: modules/database.am:593
+msgid " AppImages with 🔒 are sandboxed with sas"
+msgstr ""
+
+#: modules/database.am:595
+msgid " Versions with 🔒 are locked"
+msgstr ""
+
+#: modules/template.am:292
+msgid " Latest release (y) or a generic one (N or leave blank)?"
+msgstr ""
+
+#: modules/template.am:308
+msgid " Do you wish to check the link (Y,n)?"
+msgstr ""
+
+#: modules/template.am:321
+msgid " If correct, press \"ENTER\", 1 to add keywords and 2 to remove keywords: "
+msgstr ""
+
+#: modules/template.am:324
+msgid " URL must contain (\"x64\", \"x86_64\"... or leave blank): "
+msgstr ""
+
+#: modules/template.am:327
+msgid " Do you wish to check the link for the last time (Y,n)?"
+msgstr ""
+
+#: modules/template.am:341
+msgid " URL must NOT contain (\"txt\", \"ARM\"... or leave blank): "
+msgstr ""
+
+#: modules/template.am:555
+msgid " ◆ NAME OF THE APP (for the \"Name\" entry of the .desktop file): "
+msgstr ""
+#: modules/template.am:111
+msgid " USE A ONE-LINE COMMAND TO CHECK THE URL TO THE PROGRAM OR THE VERSION\n\n if the URL is fixed, simply add the \"echo\" command at the beginning\n\n :"
+msgstr ""


### PR DESCRIPTION
While working on the Russian translation, I noticed that some strings never appeared translated. 

In a previous discussion, one of these strings (`No apps to update here!`) was pointed out as already translatable - but it was actually using `$'...'`, so it was never being translated.

This PR replaces `$'...'` with `$"..."` for all strings that are intended to be localized, and adds the corresponding translation entries for all supported languages.