### PR TITLE
Removed unnecessary quotes around arithmetic expression.

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -94,7 +94,8 @@ Gold='\033[0;33m'
 Green='\033[0;32m'
 LightBlue='\033[1;34m'
 
-command -v tput >/dev/null 2>&1 && TERMINAL_WIDTH="$(("$(tput cols)"-"3"))" || TERMINAL_WIDTH="${COLUMNS:-80}"
+# Detect terminal width and create dividing line
+command -v tput >/dev/null 2>&1 && TERMINAL_WIDTH=$(($(tput cols)-3)) || TERMINAL_WIDTH=${COLUMNS:-80}
 DIVIDING_LINE=$(printf '%*s' "$TERMINAL_WIDTH" '' | tr ' ' '-')
 
 # Fit texts to an acceptable width
@@ -1723,7 +1724,7 @@ _update_determine_gh_apps_number() {
 	[ -z "$GH_APPS" ] && GH_APPS_NUMBER="" || GH_APPS_NUMBER=$(echo "$GH_APPS" | wc -l | sed 's/ //g')
 	if [ -n "$GH_APPS_NUMBER" ]; then
 		GH_API_REMAINING=$(curl -Ls "https://api.github.com/rate_limit" | tr '{,' '\n' | grep -i remaining | tail -1 | grep -Eo "[0-9]*")
-		GH_API_ALLOWED=$(("$GH_API_REMAINING"-"$GH_APPS_NUMBER"))
+		GH_API_ALLOWED=$(($GH_API_REMAINING-$GH_APPS_NUMBER))
 	fi
 }
 


### PR DESCRIPTION
Fix for a syntax error caused by the nested quotes for arithmetic expansion. Most modern shells will forgive this error, but Debian Jessie does not:
```
/usr/local/bin/am: line 97: "205"-"3": syntax error: operand expected (error token is ""205"-"3"")

 YOU HAVE INSTALLED 1 PROGRAM MANAGED BY "AM"

 - APPNAME | VERSION | TYPE           | SIZE
 - ------- | ------- | ----           | ----
 ◆ am      | 10.1-2  | dynamic-binary | 225.24 KiB

 TOTAL SIZE: 225.24 KiB of disk space in use
```

And also this error:
`fold: invalid number of columns: ‘’`

In POSIX sh, the $((...)) construct doesn't require quotes around the inner command substitution. Quotes can interfere with proper parsing in some shells, causing it to not interpreting the quotes incorrectly, breaking the math operation.