### PR TITLE
Option -f, fix sizes shown in the table, on freeBSD

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -340,6 +340,14 @@ _files_db() {
 }
 
 # CREATE THE TABLE
+_du_bytes() {
+	if du -sb . >/dev/null 2>&1; then
+		du -sb "$1"
+	else
+		du -sk "$1" | awk '{print $1 * 1024}'
+	fi
+}
+
 _files() {
 	cd "$APPSPATH" || exit 1
 	# Compute bytes for installed apps once to avoid repeated du calls and rescanning large trees.
@@ -395,7 +403,7 @@ _files() {
 			(
 				[ -z "$path" ] && exit 0
 				# Measure entire tree for this app (includes data dirs like Steam's)
-				bytes=$(du -sb "$path" 2>/dev/null | awk '{print $1}' || true)
+				bytes=$(_du_bytes "$path" 2>/dev/null | awk '{print $1}' || true)
 				if echo "$bytes" | grep -qE '^[0-9]+$'; then
 					printf "%s\t%s\n" "$bytes" "$path" >>"$TMPDU"
 				else
@@ -604,7 +612,7 @@ _files_total_size() {
 			TOTAL_BYTES=$(echo "$FILES_SIZES_BYTES_CONTENT" | awk '{s+=$4}END{print s+0}')
 		else
 			# Fallback: sum exact bytes with du -sb (may be slower)
-			TOTAL_BYTES=$(du -sb $INSTALLED_APPS_PLAN 2>/dev/null | awk '{s+=$1}END{print s+0}')
+			TOTAL_BYTES=$(_du_bytes $INSTALLED_APPS_PLAN 2>/dev/null | awk '{s+=$1}END{print s+0}')
 		fi
 
 		# Format total using _hr_bytes (returns e.g. "123.00G" / "301.40M" / "199.00K" / "5.00B")


### PR DESCRIPTION
The "du" command in freeBSD doesn't have the -b option for bytes. With this commit, we're falling back on kilobytes (-k option), attempting to multiply them enough to provide an approximate byte value that's compatible with the new scheme provided by @fiftydinar in https://github.com/ivan-hc/AM/pull/2195

| before | after |
| - | - |
| <img width="1024" height="766" alt="Istantanea_2026-05-08_02-36-48" src="https://github.com/user-attachments/assets/f3d35c1a-2f2e-4a9e-9c3b-8643520abf35" /> | <img width="1023" height="767" alt="Istantanea_2026-05-08_02-35-46" src="https://github.com/user-attachments/assets/7c9bbc47-0bf4-4ef0-b7b1-2a2f8c5805ad" /> |

The problem with the `column` command, however, is another story. Don't worry about the alignment. On FreeBSD, everything is a bit broken... but we'll gradually fix it.