### PR TITLE
`database.am`: Fix option `-f` speed regression

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -341,11 +341,13 @@ _files_db() {
 
 # CREATE THE TABLE
 _du_bytes() {
-	if du -sb . >/dev/null 2>&1; then
-		du -sb "$1"
-	else
-		du -sk "$1" | awk '{print $1 * 1024}'
-	fi
+    _output=$(du -sb "$1")
+    _status=$?
+    if [ $_status -eq 64 ] || [ $_status -ne 0 ]; then
+    	du -sk "$1" | awk '{print $1 * 1024}'
+    else
+        echo "$_output"
+    fi
 }
 
 _files() {


### PR DESCRIPTION
It was introduced by this commit:
https://github.com/ivan-hc/AM/commit/146152bb614700dae78cb534b22c0b809a26be89

Running `du -sb .` as a check is expensive, so I simply catch the error code instead. bsd's `du` outputs error code 64 for non-available option, but I also check for error code other than 0.

We can use the shell arithmetic calculation instead of `awk`, but I use `awk` here, because of 32bit shell limitations (precision up to ~2GiB. After that, it shows wrong info). And I saw the Raspberry Pi OS having 64 bit kernel, while other apps are 32 bit, including shell.

`du -sk` outputs slightly different file sizes compared to `du -sb`, but it's still relatively accurate. It's also slightly slower, but not a big deal (and not visible like with my system with 100 GBs of data).

This makes it fast like it was before, while retaining support for BSD, Busybox and GNU utilities.