### PR TITLE
Fix for "REcompile() - panic:  parser returns ERR_7" error in some distros.

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -845,7 +845,7 @@ _check_version_filters() {
 		}
 
 		# 1. Full semantic version (X.Y.Z or similar)
-		if (match($0, /v?[0-9]+(\.[0-9]+)*(-[0-9]+(-g[0-9a-f]+)?)?/)) {
+        if (match($0, /v?[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*/)) {
 			print substr($0, RSTART, RLENGTH)
 			exit
 		}

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -845,7 +845,7 @@ _check_version_filters() {
 		}
 
 		# 1. Full semantic version (X.Y.Z or similar)
-		if (match($0, /v?[0-9]+(\.[0-9]+){1,}(-[0-9]+(-g[0-9a-f]+)?)?/)) {
+		if (match($0, /v?[0-9]+(\.[0-9]+)*(-[0-9]+(-g[0-9a-f]+)?)?/)) {
 			print substr($0, RSTART, RLENGTH)
 			exit
 		}

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -845,7 +845,7 @@ _check_version_filters() {
 		}
 
 		# 1. Full semantic version (X.Y.Z or similar)
-        if (match($0, /v?[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*/)) {
+		if (match($0, /v?[0-9]+\.[0-9]+(\.[0-9]+)*(-[0-9]+(-g[0-9a-f]+)?)?/)) {
 			print substr($0, RSTART, RLENGTH)
 			exit
 		}


### PR DESCRIPTION
Isolated the error to the function _check_version_filters(). Ran the the awk regex pattern through a model to isolate the error reported in #2334.

The issue was the `{1,}` quantifier applied directly to a capturing group `(\.[0-9]+){1,}`. By changing it to `(\.[0-9]+)*`, it becomes compatible with POSIX awk regex.