### PR TITLE
Fixed logical mistake in dependency prompt message

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -564,7 +564,7 @@ if uname | grep -q BSD; then
 else
 	missing_cmd_msg_header=$(echo $"The following commands are missing and can be temporarily downloaded from https://github.com/ivan-hc/am-utils as static binaries")
 fi
-missing_cmd_msg_footer=$(echo $"Press \"Y\" to store them in cache until you clear it (with \"-c\" option) or install them (ideally via your package manager). Press \"N\" to ignore this message (default).")
+missing_cmd_msg_footer=$(echo $"Press \"Y\" to store them in cache until you clear it (with \"-c\" option), or press \"N\" to ignore this message and install them manually (default).")
 
 _collect_fallback_dependencies() {
 	if [ -z "$fallback_binaries_needed" ]; then


### PR DESCRIPTION
Simplified and fixed logical mistake in dependency prompt message explanation.
- **Before**: Press Y **OR** install manually **OR** Press N.
`missing_cmd_msg_footer=$(echo $"Press \"Y\" to store them in cache until you clear it (with \"-c\" option) or install them (ideally via your package manager). Press \"N\" to ignore this message (default).")`
- **After**: Press Y, **OR** Press N **AND** install manually.
`missing_cmd_msg_footer=$(echo $"Press \"Y\" to store them in cache until you clear it (with \"-c\" option), or press \"N\" to ignore this message and install them manually (default).")`

Rationale: Users who will press "N" usually know what they are doing. They will not require too much details as they have to research the missing package names anyway.