### PR TITLE
Added debug switch support for _use_verify()

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1788,6 +1788,10 @@ _use_verify() {
 			printf "%b⚠️\033[0m %b \n" "${Gold}" "$checksum_msg" | _fit
 			return 1
 		fi
+		# Show URL and digest when in debug mode
+		if [ -n "$debug_update" ]; then
+			printf "Download URL: ${download_url}, Digest: ${digest}\n"
+		fi
 		# Calculate checksums
 		if [ -f "$argpath"/"$arg" ]; then
 			checksum_sha1=$(sha1sum "$argpath/$arg" | awk '{print $1}')

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1789,9 +1789,7 @@ _use_verify() {
 			return 1
 		fi
 		# Show URL and digest when in debug mode
-		if [ -n "$debug_update" ]; then
-			printf "Download URL: ${download_url}, Digest: ${digest}\n"
-		fi
+		[ -n "$debug_update" ] && printf "\nDownload URL: %s, Digest: %s\n" "$download_url" "$digest"
 		# Calculate checksums
 		if [ -f "$argpath"/"$arg" ]; then
 			checksum_sha1=$(sha1sum "$argpath/$arg" | awk '{print $1}')


### PR DESCRIPTION
Will help to simplify debugging bad checksum URLs via `am -u --debug`. We can ask the users to run this for us as well.