### PR TITLE
Added new test-am-utils.sh and other regression testing updates

### DIFF
--- a/regress/am-alpine.dockerfile
+++ b/regress/am-alpine.dockerfile
@@ -17,7 +17,7 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # Setup AM with safe defaults
-RUN printf "y\n\n" | am --user && am --system && am --disable-notifications
+RUN printf "Y\n\n" | am --user && am --system && am --disable-notifications
 
 # Setup env
 RUN echo "export PATH=$PATH:/root/.local/bin" >> ~/.bashrc

--- a/regress/am-arch.dockerfile
+++ b/regress/am-arch.dockerfile
@@ -6,7 +6,7 @@
 FROM archlinux:latest
 
 # Install dependencies and AM
-RUN pacman-key --init && pacman -Sy && pacman -Su --noconfirm sudo wget curl less git glibc fuse3 file unzip xz 7zip libnotify
+RUN pacman-key --init && pacman -Sy && pacman -Su --noconfirm sudo wget curl less git glibc fuse3 file unzip xz 7zip libnotify which
 RUN cd && wget https://raw.githubusercontent.com/ivan-hc/AM/main/INSTALL && chmod a+x ./INSTALL && sudo ./INSTALL && rm ./INSTALL
 
 # Copy regression folder

--- a/regress/am-arch.dockerfile
+++ b/regress/am-arch.dockerfile
@@ -18,7 +18,7 @@ RUN locale-gen && echo "LANG=en_US.UTF-8" > /etc/locale.conf
 ENV LC_ALL en_US.UTF-8
 
 # Setup AM with safe defaults
-RUN printf "y\n\n" | am --user && am --system && am --disable-notifications
+RUN printf "Y\n\n" | am --user && am --system && am --disable-notifications
 
 # Setup env
 RUN echo "export PATH=$PATH:/root/.local/bin" >> ~/.bashrc

--- a/regress/am-debian-old.dockerfile
+++ b/regress/am-debian-old.dockerfile
@@ -21,7 +21,7 @@ RUN locale-gen && update-locale LANG=en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # Setup AM with safe defaults
-RUN printf "y\n\n" | am --user && am --system && am --disable-notifications
+RUN printf "Y\n\n" | am --user && am --system && am --disable-notifications
 
 # Setup env
 RUN echo "export PATH=$PATH:/root/.local/bin" >> ~/.bashrc

--- a/regress/am-debian-old.dockerfile
+++ b/regress/am-debian-old.dockerfile
@@ -5,12 +5,11 @@
 # Use the official Debian Jessie image as a parent image
 FROM debian:jessie
 
-# Install dependencies and AM
-# Notes: 7zip not available in Jessie, and GPG warnings is normal, repos are archieved
+# Install dependencies and AM (GPG warnings are normal as repos are archieved)
 RUN echo 'deb http://archive.debian.org/debian jessie main contrib non-free' > /etc/apt/sources.list
 RUN echo 'deb http://archive.debian.org/debian-security jessie/updates main contrib non-free' >> /etc/apt/sources.list
 RUN echo 'Apt::Get::AllowUnauthenticated "true";' > /etc/apt/apt.conf.d/99verify-apt-https
-RUN apt update && apt full-upgrade -y && apt install -y sudo wget curl git fuse bsdmainutils file locales unzip xz-utils libterm-readline-gnu-perl libnotify-bin binutils
+RUN apt update && apt full-upgrade -y && apt install -y sudo wget curl git fuse bsdmainutils file locales unzip xz-utils libterm-readline-gnu-perl libnotify-bin p7zip-full binutils
 RUN cd && wget https://raw.githubusercontent.com/ivan-hc/AM/main/INSTALL && chmod a+x ./INSTALL && sudo ./INSTALL && rm ./INSTALL
 
 # Copy regression folder

--- a/regress/am-debian.dockerfile
+++ b/regress/am-debian.dockerfile
@@ -18,7 +18,7 @@ RUN locale-gen && update-locale LANG=en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # Setup AM with safe defaults
-RUN printf "y\n\n" | am --user && am --system && am --disable-notifications
+RUN printf "Y\n\n" | am --user && am --system && am --disable-notifications
 
 # Setup env
 RUN echo "export PATH=$PATH:/root/.local/bin" >> ~/.bashrc

--- a/regress/am-ubuntu.dockerfile
+++ b/regress/am-ubuntu.dockerfile
@@ -18,7 +18,7 @@ RUN locale-gen && update-locale LANG=en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # Setup AM with safe defaults
-RUN printf "y\n\n" | am --user && am --system && am --disable-notifications
+RUN printf "Y\n\n" | am --user && am --system && am --disable-notifications
 
 # Setup env
 RUN echo "export PATH=$PATH:/root/.local/bin" >> ~/.bashrc

--- a/regress/test-am-checksum.sh
+++ b/regress/test-am-checksum.sh
@@ -11,7 +11,7 @@ app_name_digest=$(_pick_random_app "$TEST_APP_LIST_DIG")
 app_name_zip=$(_pick_random_app "$TEST_APP_LIST_ZIP")
 app_name_nochk=$(_pick_random_app "$TEST_APP_LIST_NOCHK")
 
-## Setup
+# Setup
 _log "Running checksum test: $0"
 am --system
 

--- a/regress/test-am-checksum.sh
+++ b/regress/test-am-checksum.sh
@@ -38,6 +38,9 @@ _check_count "checksum auto-verified" 1 "$test_results"
 am -i "$app_name_nochk" > "$test_results"
 _check_count "checksum verified" 0 "$test_results"
 
+# Check if apps were installed correctly
+_test_apps "$app_name1 $app_name2 $app_name_digest $app_name_zip $app_name_nochk"
+
 # Pass the test
 _remove_all_apps
 _pass

--- a/regress/test-am-clone.sh
+++ b/regress/test-am-clone.sh
@@ -9,7 +9,7 @@ app_name1=$(_pick_random_app "$TEST_APP_LIST_ZIP")
 app_name2=$(_pick_random_app "$TEST_APP_LIST_ZSYNC")
 app_name3=$(_pick_random_app "$TEST_APP_LIST_NOCHK")
 
-## Setup
+# Setup
 _log "Running clone install list test: $0"
 rm -f ~/Desktop/am-clone.source am-clone.source
 _remove_all_apps
@@ -21,7 +21,7 @@ am -i "$app_name1" "$app_name2" "$app_name3"
 
 # Install in User Mode
 _log "Installing all apps in user mode..."
-printf "y\n" |\
+printf "Y\n" |\
 am --user
 am -i "$app_name1" "$app_name2" "$app_name3"
 
@@ -34,10 +34,10 @@ _check_count "$app_name2.*|" 2 "$test_results"
 _check_count "$app_name3.*|" 2 "$test_results"
 
 # Hide/lock apps to complicate clone process
-printf "y\n" |\
+printf "Y\n" |\
 am --user
 am hide "$app_name1"
-printf "y\n" |\
+printf "Y\n" |\
 am lock "$app_name2"
 am --system
 printf "1\n" |\
@@ -53,7 +53,7 @@ _check_count "am-clone.source" 1 "$test_results"
 
 # Remove all apps and and then reinstall them (clone previous setup)
 _remove_all_apps
-printf "y\n" |\
+printf "Y\n" |\
 am clone install
 
 # Check listing

--- a/regress/test-am-clone.sh
+++ b/regress/test-am-clone.sh
@@ -64,6 +64,9 @@ _check_count "$app_name1.*|" 1 "$test_results"
 _check_count "$app_name2.*|" 1 "$test_results"
 _check_count "$app_name3.*|" 2 "$test_results"
 
+# Check if apps were installed correctly
+_test_apps "$app_name1 $app_name2 $app_name3"
+
 # Pass the test
 _remove_all_apps
 _pass

--- a/regress/test-am-hide.sh
+++ b/regress/test-am-hide.sh
@@ -8,11 +8,11 @@ test_results=".results.tmp"
 app_name1=$(_pick_random_app "$TEST_APP_LIST_ZIP") && TEST_APP_LIST_ZIP=$(_remove_item "$TEST_APP_LIST_ZIP" "$app_name1")
 app_name2=$(_pick_random_app "$TEST_APP_LIST_ZIP")
 
-## Setup
+# Setup
 _log "Running hide/unhide test: $0"
 
 # Install app locally
-printf "y\n" |\
+printf "Y\n" |\
 am --user
 am -i "$app_name1"
 

--- a/regress/test-am-hide.sh
+++ b/regress/test-am-hide.sh
@@ -21,12 +21,14 @@ _log "Test hide $app_name1 (local)..."
 am hide "$app_name1"
 am -f > "$test_results"
 _check_count "$app_name1.*|" 0 "$test_results"
+_test_apps "$app_name1"
 
 # Test unhide
 _log "Test unhide $app_name1 (local)..."
 am unhide "$app_name1"
 am -f > "$test_results"
 _check_count "$app_name1.*|" 1 "$test_results"
+_test_apps "$app_name1"
 
 # Install apps in system level
 am --system
@@ -44,6 +46,7 @@ _log "Test hide $app_name2..."
 am hide "$app_name2"
 am -f > "$test_results"
 _check_count "$app_name2.*|" 0 "$test_results"
+_test_apps "$app_name1 $app_name2"
 
 # Test unhide
 _log "Test unhide $app_name1..."
@@ -51,11 +54,12 @@ am unhide "$app_name1"
 am -f > "$test_results"
 _check_count "$app_name1.*|" 2 "$test_results"
 
-# Test hide for another app
+# Test unhide for another app
 _log "Test unhide $app_name2..."
 am unhide "$app_name2"
 am -f > "$test_results"
 _check_count "$app_name2.*|" 1 "$test_results"
+_test_apps "$app_name1 $app_name2"
 
 # Pass the test
 _remove_all_apps

--- a/regress/test-am-install.sh
+++ b/regress/test-am-install.sh
@@ -15,12 +15,14 @@ am --system
 # Install in System Mode
 _log "Installing $app_name in system mode..."
 am -i "$app_name"
+_test_apps "$app_name"
 
 # Install in User Mode
 _log "Installing $app_name in user mode..."
 printf "Y\n" |\
 am --user
 am -i "$app_name"
+_test_apps "$app_name"
 
 # Check Listing
 _log "Checking if $app_name is installed in both user/system modes..."
@@ -43,6 +45,7 @@ _check_count "$app_name.*|" 0 "$test_results"
 # Reinstall in User Mode
 _log "Installing $app_name in user mode again..."
 am -i "$app_name"
+_test_apps "$app_name"
 
 # Remove in System Mode and User Mode (option 2)
 _log "Removing $app_name in user & system mode..."
@@ -60,6 +63,7 @@ _check_count "$app_name.*|" 0 "$test_results"
 _log "Installing $app_name_old (outdated) in both system/user modes..."
 am -i "$app_name_old"
 am -i --user "$app_name_old"
+_test_apps "$app_name_old"
 
 # Check for "old release msg"
 _log "Checking if $app_name_old (outdated) is listed in both system/user modes with warnings..."

--- a/regress/test-am-install.sh
+++ b/regress/test-am-install.sh
@@ -8,7 +8,7 @@ test_results=".results.tmp"
 app_name=$(_pick_random_app "$TEST_APP_LIST_ZIP")
 app_name_old=$(_pick_random_app "$TEST_APP_LIST_OLD")
 
-## Setup
+# Setup
 _log "Running multi-user install test: $0"
 am --system
 
@@ -18,7 +18,7 @@ am -i "$app_name"
 
 # Install in User Mode
 _log "Installing $app_name in user mode..."
-printf "y\n" |\
+printf "Y\n" |\
 am --user
 am -i "$app_name"
 
@@ -30,9 +30,9 @@ _check_count "$app_name.*|" 2 "$test_results"
 
 # Remove in User Mode
 _log "Removing $app_name in user mode..."
-printf "y\n" |\
+printf "Y\n" |\
 am --user
-printf "y\n" |\
+printf "Y\n" |\
 am -r "$app_name"
 
 # Check for Errors

--- a/regress/test-am-nolibfuse.sh
+++ b/regress/test-am-nolibfuse.sh
@@ -7,8 +7,9 @@
 test_results=".results.tmp"
 app_name="bench-cli"
 
-## Setup
+# Setup
 _log "Running libfuse2 removal test: $0"
+_hide_libfuse2
 am --system
 
 # Install a known archived command line tool that uses libfuse2
@@ -32,6 +33,7 @@ _log "Testing app to see if libfuse2 error is gone..."
 _check_count "error.*libfuse" 0 "$test_results"
 
 # Pass the test
+_restore_libfuse2
 _remove_all_apps
 _pass
 

--- a/regress/test-am-nolibfuse.sh
+++ b/regress/test-am-nolibfuse.sh
@@ -24,7 +24,7 @@ _check_count "error.*libfuse" 1 "$test_results"
 
 # Remove libfuse2 dependency
 _log "Removing libfuse2 dependency..."
-printf "y\n" |\
+printf "Y\n" |\
 am nolibfuse "$app_name"
 
 # Test app

--- a/regress/test-am-regress.sh
+++ b/regress/test-am-regress.sh
@@ -6,7 +6,7 @@
 # Setup
 rm -f $TEST_LOG
 _log "Regression testing setup:"
-_restore_binaries
+_restore_binaries "$AM_OPT_DEPS"
 _remove_all_apps
 am --system
 am clean

--- a/regress/test-am-regress.sh
+++ b/regress/test-am-regress.sh
@@ -6,7 +6,7 @@
 # Setup
 rm -f $TEST_LOG
 _log "Regression testing setup:"
-_restore_binaries "$AM_OPT_DEPS"
+_restore_binaries
 _remove_all_apps
 am --system
 am clean

--- a/regress/test-am-regress.sh
+++ b/regress/test-am-regress.sh
@@ -20,6 +20,7 @@ _log "Done.\n"
 ./test-am-nolibfuse.sh
 ./test-am-rollback.sh
 ./test-am-clone.sh
+./test-am-utils.sh
 
 # Done
 _log "Regression testing complete:"

--- a/regress/test-am-regress.sh
+++ b/regress/test-am-regress.sh
@@ -6,6 +6,7 @@
 # Setup
 rm -f $TEST_LOG
 _log "Regression testing setup:"
+_restore_binaries "$AM_OPT_DEPS"
 _remove_all_apps
 am --system
 am clean

--- a/regress/test-am-repair.sh
+++ b/regress/test-am-repair.sh
@@ -32,6 +32,7 @@ _log "Fixing $app_name and checking for checksum verification success..."
 am -u "$app_name"
 am -f > "$test_results"
 _check_count "$app_name.*\✓" 1 "$test_results"
+_test_apps "$app_name"
 
 # Pass the test
 _remove_all_apps

--- a/regress/test-am-repair.sh
+++ b/regress/test-am-repair.sh
@@ -7,7 +7,7 @@
 test_results=".results.tmp"
 app_name=$(_pick_random_app "$TEST_APP_LIST_ZSYNC")
 
-## Setup
+# Setup
 _log "Running app repair test: $0"
 am --system
 

--- a/regress/test-am-rollback.sh
+++ b/regress/test-am-rollback.sh
@@ -7,7 +7,7 @@
 test_results=".results.tmp"
 app_name1=$(_pick_random_app "$TEST_APP_LIST_DOWN")
 
-## Setup
+# Setup
 _log "Running version rollback test: $0"
 am --system
 am -R "$app_name1"
@@ -21,21 +21,21 @@ app_ver_latest="$(_get_app_info "$app_name1" 2)"
 
 # Test rollback
 _log "Test rollback $app_name1..."
-printf "y\n2\n" |\
+printf "Y\n2\n" |\
 am downgrade "$app_name1"
 app_ver_old="$(_get_app_info "$app_name1" 2)"
 [ "$app_ver_old" = "$app_ver_latest" ] && _fail "Error: \"$app_name1\" version rollback failed"
 
 # Test lock
 _log "Test lock $app_name1..."
-printf "y\n" |\
+printf "Y\n" |\
 am lock "$app_name1"
 app_ver_old_locked="$(_get_app_info "$app_name1" 2)"
 [ "$app_ver_old_locked" = "$app_ver_old" ] && _fail "Error: \"$app_name1\" version lock failed"
 
 # Test backup
 _log "Backing up old version of $app_name1..."
-printf "y\n\n" |\
+printf "Y\n\n" |\
 am backup "$app_name1"
 
 # Try to update locked app
@@ -47,7 +47,7 @@ app_ver_old_updated="$(_get_app_info "$app_name1" 2)"
 
 # Test unlock
 _log "Test unlock $app_name1..."
-printf "y\n" |\
+printf "Y\n" |\
 am unlock "$app_name1"
 app_ver_old_unlocked="$(_get_app_info "$app_name1" 2)"
 [ "$app_ver_old_unlocked" != "$app_ver_old" ] && _fail "Error: \"$app_name1\" version unlock failed"
@@ -61,7 +61,7 @@ app_ver_old_updated="$(_get_app_info "$app_name1" 2)"
 
 # Test restore
 _log "Test restore backed up version of $app_name1..."
-printf "y\n1\n" |\
+printf "Y\n1\n" |\
 am -o "$app_name1"
 app_ver_old_restored="$(_get_app_info "$app_name1" 2)"
 [ "$app_ver_old_restored" != "$app_ver_old_locked" ] && _fail "Error: \"$app_name1\" version was not restored correctly"

--- a/regress/test-am-rollback.sh
+++ b/regress/test-am-rollback.sh
@@ -18,6 +18,7 @@ am -i "$app_name1"
 am -f > "$test_results"
 _check_count "$app_name1.*|" 1 "$test_results"
 app_ver_latest="$(_get_app_info "$app_name1" 2)"
+_test_apps "$app_name1"
 
 # Test rollback
 _log "Test rollback $app_name1..."
@@ -25,6 +26,7 @@ printf "Y\n2\n" |\
 am downgrade "$app_name1"
 app_ver_old="$(_get_app_info "$app_name1" 2)"
 [ "$app_ver_old" = "$app_ver_latest" ] && _fail "Error: \"$app_name1\" version rollback failed"
+_test_apps "$app_name1"
 
 # Test lock
 _log "Test lock $app_name1..."
@@ -58,6 +60,7 @@ am -u "$app_name1" > "$test_results"
 _check_count "cannot be updated" 0 "$test_results"
 app_ver_old_updated="$(_get_app_info "$app_name1" 2)"
 [ "$app_ver_old_updated" != "$app_ver_latest" ] && _fail "Error: \"$app_name1\" version cannot be updated despite unlocked status"
+_test_apps "$app_name1"
 
 # Test restore
 _log "Test restore backed up version of $app_name1..."
@@ -65,6 +68,7 @@ printf "Y\n1\n" |\
 am -o "$app_name1"
 app_ver_old_restored="$(_get_app_info "$app_name1" 2)"
 [ "$app_ver_old_restored" != "$app_ver_old_locked" ] && _fail "Error: \"$app_name1\" version was not restored correctly"
+_test_apps "$app_name1"
 
 # Pass the test
 rm -rf ~/.am-snapshots

--- a/regress/test-am-sandbox.sh
+++ b/regress/test-am-sandbox.sh
@@ -6,7 +6,7 @@
 # Test variables
 test_results=".results.tmp"
 
-## Setup
+# Setup
 _log "Running sandbox test: $0"
 mkdir -p ~/Desktop/test_dir
 mkdir -p ~/Documents/test_dir
@@ -18,7 +18,7 @@ am -i aisap
 # Install and sandbox a simple appimage command line tool
 _log "Sandboxing app (access to only ~/Desktop)..."
 am -R bench-cli
-printf "y\ny\nn\nn\nn\nn\nn\nn\nn\n" |\
+printf "Y\nY\nN\nN\nN\nN\nN\nN\nN\n" |\
 am -ias bench-cli
 
 # Test directory access
@@ -35,7 +35,7 @@ am --disable-sandbox bench-cli
 
 # Remove libfuse2 dependency
 _log "Removing libfuse2 dependency..."
-printf "y\n" |\
+printf "Y\n" |\
 am nolibfuse bench-cli
 
 # Test directory access

--- a/regress/test-am-utils.sh
+++ b/regress/test-am-utils.sh
@@ -15,7 +15,7 @@ all_apps="$app_name1 $app_name2 $app_name3 $app_name4"
 _log "Running am-utils dependency test: $0"
 
 # Hide core tools and check if AM detects them as missing
-_hide_binaries "$AM_OPT_DEPS"
+_hide_binaries
 printf "N\n" |\
 am clean
 printf "N\n" |\
@@ -35,13 +35,7 @@ _check_count "Missing command(s)" 0 "$test_results"
 _log "Installing all apps in system mode..."
 am -i "$all_apps" > "$test_results"
 _check_count "checksum.*verified" 4 "$test_results"
-
-# Check if apps were installed correctly
-for prog in $all_apps; do
-    if ! command -v "$prog" > /dev/null 2>&1; then
-		_fail "Error: $prog was not installed correctly (--system)."
-    fi
-done
+_test_apps "$all_apps"
 
 # Install in User Mode
 _log "Installing all apps in user mode..."
@@ -50,16 +44,10 @@ printf "Y\n" |\
 am --user
 am -i "$all_apps" > "$test_results"
 _check_count "checksum.*verified" 4 "$test_results"
-
-# Check if apps were installed correctly
-for prog in $all_apps; do
-    if ! command -v "$prog" > /dev/null 2>&1; then
-		_fail "Error: $prog was not installed correctly (--user)."
-    fi
-done
+_test_apps "$all_apps"
 
 # Restore binaries
-_restore_binaries "$AM_OPT_DEPS"
+_restore_binaries
 am clean
 printf "N\n" |\
 am -f > "$test_results"

--- a/regress/test-am-utils.sh
+++ b/regress/test-am-utils.sh
@@ -15,7 +15,7 @@ all_apps="$app_name1 $app_name2 $app_name3 $app_name4"
 _log "Running am-utils dependency test: $0"
 
 # Hide core tools and check if AM detects them as missing
-_hide_binaries
+_hide_binaries "$AM_OPT_DEPS"
 printf "N\n" |\
 am clean
 printf "N\n" |\
@@ -47,7 +47,7 @@ _check_count "checksum.*verified" 4 "$test_results"
 _test_apps "$all_apps"
 
 # Restore binaries
-_restore_binaries
+_restore_binaries "$AM_OPT_DEPS"
 am clean
 printf "N\n" |\
 am -f > "$test_results"

--- a/regress/test-am-utils.sh
+++ b/regress/test-am-utils.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env sh
+
+# Source common test functions
+. "$(dirname "$0")/test-common.sh"
+
+# Test variables
+test_results=".results.tmp"
+am_opt_deps="7z ar md5sum sha1sum sha256sum sha512sum tar unzip wget xz xzcat"
+app_name1=$(_pick_random_app "$TEST_APP_LIST_XZ")
+app_name2=$(_pick_random_app "$TEST_APP_LIST_ZIP")
+app_name3=$(_pick_random_app "$TEST_APP_LIST_DIG")
+app_name4=$(_pick_random_app "$TEST_APP_LIST_ZSYNC")
+all_apps="$app_name1 $app_name2 $app_name3 $app_name4"
+
+# Setup
+_log "Running am-utils dependency test: $0"
+
+# Hide core tools and check if AM detects them as missing
+_hide_binaries "$am_opt_deps"
+printf "N\n" |\
+am clean
+printf "N\n" |\
+am --system
+am -f > "$test_results"
+_check_count "Missing command(s)" 1 "$test_results"
+
+# Force AM to download them (Y first, then N if experiencing network issues)
+rm -f ~/.local/share/AM/disable-dependencies-prompt
+printf "Y\n" |\
+am -f
+printf "N\n" |\
+am -f > "$test_results"
+_check_count "Missing command(s)" 0 "$test_results"
+
+# Install in System Mode
+_log "Installing all apps in system mode..."
+am -i "$all_apps" > "$test_results"
+_check_count "checksum.*verified" 4 "$test_results"
+
+# Check if apps were installed correctly
+for prog in $all_apps; do
+    if ! command -v "$prog" > /dev/null 2>&1; then
+		_fail "Error: $prog was not installed correctly (--system)."
+    fi
+done
+
+# Install in User Mode
+_log "Installing all apps in user mode..."
+am -R "$all_apps"
+printf "Y\n" |\
+am --user
+am -i "$all_apps" > "$test_results"
+_check_count "checksum.*verified" 4 "$test_results"
+
+# Check if apps were installed correctly
+for prog in $all_apps; do
+    if ! command -v "$prog" > /dev/null 2>&1; then
+		_fail "Error: $prog was not installed correctly (--user)."
+    fi
+done
+
+# Restore binaries
+_restore_binaries "$am_opt_deps"
+am clean
+printf "N\n" |\
+am -f > "$test_results"
+_check_count "Missing command(s)" 0 "$test_results"
+
+# Pass the test
+_remove_all_apps
+_pass
+

--- a/regress/test-am-utils.sh
+++ b/regress/test-am-utils.sh
@@ -5,7 +5,6 @@
 
 # Test variables
 test_results=".results.tmp"
-am_opt_deps="7z ar md5sum sha1sum sha256sum sha512sum tar unzip wget xz xzcat"
 app_name1=$(_pick_random_app "$TEST_APP_LIST_XZ")
 app_name2=$(_pick_random_app "$TEST_APP_LIST_ZIP")
 app_name3=$(_pick_random_app "$TEST_APP_LIST_DIG")
@@ -16,7 +15,7 @@ all_apps="$app_name1 $app_name2 $app_name3 $app_name4"
 _log "Running am-utils dependency test: $0"
 
 # Hide core tools and check if AM detects them as missing
-_hide_binaries "$am_opt_deps"
+_hide_binaries "$AM_OPT_DEPS"
 printf "N\n" |\
 am clean
 printf "N\n" |\
@@ -60,7 +59,7 @@ for prog in $all_apps; do
 done
 
 # Restore binaries
-_restore_binaries "$am_opt_deps"
+_restore_binaries "$AM_OPT_DEPS"
 am clean
 printf "N\n" |\
 am -f > "$test_results"

--- a/regress/test-common.sh
+++ b/regress/test-common.sh
@@ -168,7 +168,11 @@ _restore_libfuse2() {
 
 # Function to hide a list binaries
 _hide_binaries() {
-	for bin in $1; do
+	# Use default list if none specified
+	binaries=$1
+	[ -z "$binaries" ] && binaries="$AM_OPT_DEPS"
+	# Iterate through list and hide each one
+	for bin in $binaries; do
 		path=$(which "$bin" 2>/dev/null)
 		[ -n "$path" ] && [ -x "$path" ] && mv "$path" "$path.bak" && sync && echo "$path hidden"
 	done
@@ -176,10 +180,23 @@ _hide_binaries() {
 
 # Function to restore a list binaries
 _restore_binaries() {
-	for bin in $1; do
+	# Use default list if none specified
+	binaries=$1
+	[ -z "$binaries" ] && binaries="$AM_OPT_DEPS"
+	# Iterate through list and restore each one
+	for bin in $binaries; do
 		path_bak=$(which "$bin.bak" 2>/dev/null)
 		path="${path_bak%.bak}"
 		[ -n "$path_bak" ] && [ -f "$path_bak" ] && mv "$path_bak" "$path" && sync && echo "$path restored"
+	done
+}
+
+# Function to test a list installed appimages if their binaries are available and executable
+_test_apps() {
+	for prog in $1; do
+		if ! command -v "$prog" > /dev/null 2>&1; then
+			_fail "Error: $prog was not installed correctly."
+		fi
 	done
 }
 

--- a/regress/test-common.sh
+++ b/regress/test-common.sh
@@ -21,6 +21,9 @@ TEST_APP_LIST_OLD="aisap bench-cli colorstatic-bash"
 # List of test apps that can be downgraded (REQUIREMENTS: Under 5MB, simple install script)
 TEST_APP_LIST_DOWN="clifm aisap fcp zsync2"
 
+# List of test apps that use tar.xz (REQUIREMENTS: Under 5MB, simple install script)
+TEST_APP_LIST_XZ="boxxy onefetch spotifetch lovesay"
+
 # Function to randomly pick an app from a list
 _pick_random_app() {
 	# Get count

--- a/regress/test-common.sh
+++ b/regress/test-common.sh
@@ -86,8 +86,8 @@ _pass() {
 # Function to remove all AM apps
 _remove_all_apps() {
 	# Remove AM local apps
-	printf "y\n" | am --user
-	apps=$(ls ~/Applications/ | xargs)
+	printf "Y\n" | am --user
+	apps=$(ls ~/Applications/ 2>/dev/null | xargs)
 	for a in $apps; do
 		am unhide "$a"
 		~/Applications/"$a"/remove
@@ -95,7 +95,7 @@ _remove_all_apps() {
 
 	# Remove AM system apps
 	am --system
-	apps=$(ls /opt/ | xargs)
+	apps=$(ls /opt/ 2>/dev/null | xargs)
 	for a in $apps; do
 		if [ "$a" != am ]; then
 			am unhide "$a"

--- a/regress/test-common.sh
+++ b/regress/test-common.sh
@@ -24,6 +24,9 @@ TEST_APP_LIST_DOWN="clifm aisap fcp zsync2"
 # List of test apps that use tar.xz (REQUIREMENTS: Under 5MB, simple install script)
 TEST_APP_LIST_XZ="boxxy onefetch spotifetch lovesay"
 
+# List of core utility apps that is to be hidden/restored for dependency testing
+AM_OPT_DEPS="7z ar md5sum sha1sum sha256sum sha512sum tar unzip wget xz xzcat"
+
 # Function to randomly pick an app from a list
 _pick_random_app() {
 	# Get count

--- a/regress/test-common.sh
+++ b/regress/test-common.sh
@@ -135,3 +135,45 @@ _check_count() {
 	fi
 }
 
+# Function to hide libfuse.so.2
+_hide_libfuse2() {
+	libfuse_path=$(find /usr/lib* /lib* -name "libfuse.so.2" 2>/dev/null | head -1)
+
+	if [ -n "$libfuse_path" ] && [ -f "$libfuse_path" ]; then
+		echo "Renaming $libfuse_path to ${libfuse_path}.bak"
+		mv "$libfuse_path" "${libfuse_path}.bak" && sync
+	else
+		echo "libfuse.so.2 not found, backup not needed."
+	fi
+}
+
+# Function to restore libfuse.so.2
+_restore_libfuse2() {
+	libfusebak_path=$(find /usr/lib* /lib* -name "libfuse.so.2.bak" 2>/dev/null | head -1)
+	libfuse_path="${libfusebak_path%.bak}"
+
+	if [ -n "$libfusebak_path" ] && [ -f "$libfusebak_path" ]; then
+		echo "Restoring $libfuse_path from ${libfusebak_path}"
+		mv "$libfusebak_path" "$libfuse_path" && sync
+	else
+		echo "libfuse.so.2.bak not found, restore not needed."
+	fi
+}
+
+# Function to hide a list binaries
+_hide_binaries() {
+	for bin in $1; do
+		path=$(which "$bin" 2>/dev/null)
+		[ -n "$path" ] && [ -x "$path" ] && mv "$path" "$path.bak" && sync && echo "$path hidden"
+	done
+}
+
+# Function to restore a list binaries
+_restore_binaries() {
+	for bin in $1; do
+		path_bak=$(which "$bin.bak" 2>/dev/null)
+		path="${path_bak%.bak}"
+		[ -n "$path_bak" ] && [ -f "$path_bak" ] && mv "$path_bak" "$path" && sync && echo "$path restored"
+	done
+}
+


### PR DESCRIPTION
Updates:
- Added new test-am-utils.sh, a dependency test to rely on am-utils as fallback.
- Resolved all dependencies for Arch and Debian Jessie containers.
- Improved keypress printf readability + cleanups.
- Added four new test related functions: 
  - Function to hide/restore libfuse.so.2: _hide_libfuse2()/_restore_libfuse2()
  - Function to hide/restore a list binaries: _hide_binaries()/_restore_binaries()
  - Function to test if an app was properly installed: _test_apps()
- Used test_apps() in all tests where appropriate.
- Improved nolibfuse test to hide lifuse.so.2 if it exists.

@ivan-hc Please take a look at test-am-utils.sh, it tests am-utils by hiding these binaries: **7z ar md5sum sha1sum sha256sum sha512sum tar unzip wget xz xzcat**. I couldn't add everything because stuff like **mv** just cannot be removed without breaking the system.

Regression is passing in all containers. AM utils binaries work even in alpine(musl) and Debian Jessie.