### PR TITLE
Add fuzzy suggest for mistyped app names during install

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -575,6 +575,75 @@ _install_3rd_party_app() {
 }
 
 ################################################################################
+#			INSTALL HELPER
+################################################################################
+
+_prepare_arg() {
+	arg_origin="$arg"
+	pure_arg=$(echo "$arg" | sed 's/\-appimage$//g' | sed 's:.*/::')
+	_remove_extensions_from_appname
+	echo "$arg" | grep -q -- "-appimage$" && _use_online_reading_tool "$APPSDB"/"$arg" | grep -q "APP=.*-appimage$" && pure_arg="$arg"
+}
+
+_check_and_install() {
+	[ -n "$BINDIR" ] && find "$BINDIR" -xtype l -name "$pure_arg" -delete 2>/dev/null
+	if test -f "$APPSPATH"/"$pure_arg"/remove || test -f "$APPSPATH"/"$pure_arg"/remove.old; then
+		echo $" ◆ \"$pure_arg\" is already installed!" | tr '[:lower:]' '[:upper:]'
+	else
+		arg_script=$(_use_online_reading_tool "$APPSDB/$arg" 2>/dev/null)
+		echo "$arg_script" | grep -q "^#" && _install_normally
+	fi
+}
+
+################################################################################
+#			DID YOU MEAN (FUZZY SUGGEST)
+################################################################################
+
+_levenshtein() {
+	local s="$1" t="$2"
+	local sl=${#s} tl=${#t}
+	local i j sc min del ins sub
+	local -a d
+	for ((i=0; i<=sl; i++)); do d[i*(tl+1)]=$i; done
+	for ((j=0; j<=tl; j++)); do d[j]=$j; done
+	for ((i=1; i<=sl; i++)); do
+		for ((j=1; j<=tl; j++)); do
+			sc=0; [ "${s:i-1:1}" != "${t:j-1:1}" ] && sc=1
+			del=$(( d[(i-1)*(tl+1)+j] + 1 ))
+			ins=$(( d[i*(tl+1)+j-1] + 1 ))
+			sub=$(( d[(i-1)*(tl+1)+j-1] + sc ))
+			min=$del; [ $ins -lt $min ] && min=$ins; [ $sub -lt $min ] && min=$sub
+			d[i*(tl+1)+j]=$min
+		done
+	done
+	echo "${d[sl*(tl+1)+tl]}"
+}
+
+_did_you_mean() {
+	local input="$1"
+	local applist="$AMDATADIR/$ARCH-apps"
+	[ ! -f "$applist" ] && return
+	local names match="" input_len=${#input} first_char="${input:0:1}" best_dist=3 diff dist
+	names=$(grep "^◆ " "$applist" | sed 's/^◆ //;s/ :.*$//')
+	while IFS= read -r name; do
+		[ -z "$name" ] && continue
+		diff=$(( ${#name} - input_len ))
+		[ $diff -lt 0 ] && diff=$(( -diff ))
+		[ $diff -gt 2 ] && continue
+		[ "${name:0:1}" != "$first_char" ] && continue
+		dist=$(_levenshtein "$input" "$name")
+		if [ "$dist" -lt "$best_dist" ]; then
+			best_dist=$dist
+			match=$name
+		fi
+	done <<< "$names"
+	if [ -n "$match" ]; then
+		printf $"\n Did you mean \"%b%b\033[0m\"?\n" "${LightBlue}" "$match"
+		DID_YOU_MEAN="$match"
+	fi
+}
+
+################################################################################
 #				USAGE
 ################################################################################
 
@@ -646,11 +715,7 @@ case "$1" in
 			[ -d "$APPSPATH"/"$arg"/tmp ] && $SUDOCMD "$APPSPATH"/"$arg"/remove 2> /dev/null
 
 			# Check if the app wil be installed with the same name as the argument
-			arg_origin="$arg"
-			pure_arg=$(echo "$arg" | sed 's/\-appimage$//g' | sed 's:.*/::')
-			_remove_extensions_from_appname
-			echo "$arg" | grep -q -- "-appimage$" && _use_online_reading_tool "$APPSDB"/"$arg" | grep -q "APP=.*-appimage$" && pure_arg="$arg"
-
+			_prepare_arg
 			arg_script=$(_use_online_reading_tool "$APPSDB/$arg" 2>/dev/null)
 
 			# Test if a symlink is broken
@@ -673,6 +738,17 @@ case "$1" in
 				_install_normally
 			else
 				echo $"💀 ERROR: \"$arg\" does NOT exist in the \"AM\" database, $(printf "please check the list, run the \"%b$AMCLIPATH_ORIGIN -l\033[0m\" command.\n\n" "${Gold}")" | fold -sw 72 | sed 's/^/ /g'
+				DID_YOU_MEAN=""
+				_did_you_mean "$arg"
+				if [ -n "$DID_YOU_MEAN" ]; then
+					read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
+					echo ""
+					if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+						arg="$DID_YOU_MEAN"
+						_prepare_arg
+						_check_and_install
+					fi
+				fi
 			fi
 			# Disable notifications if needed
 			[ -f "$AMDATADIR"/disable-notifications ] && [ -f "$APPSPATH/$LASTDIR/AM-updater" ] && sed -e '/notify-send/ s/^#*/#/' -i "$APPSPATH/$LASTDIR/AM-updater" 2>/dev/null

--- a/modules/install.am
+++ b/modules/install.am
@@ -571,6 +571,24 @@ _install_3rd_party_app() {
 	else
 		echo $" 💀 ERROR, \"$arg\" does NOT exist in 3rd-party databases"
 		printf $"\n Try again but WITHOUT the third-party flag\n"
+		local active_tp=""
+		for tp_list in $third_party_lists; do
+			echo "$FLAGS" | grep -q -- "$tp_list" && active_tp="$tp_list" && break
+		done
+		_did_you_mean "$arg" "$active_tp"
+		if [ -n "$DID_YOU_MEAN" ]; then
+			if [ -n "$DID_YOU_MEAN_FLAG" ]; then
+				read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
+			else
+				read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
+			fi
+			echo ""
+			if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+				arg="$DID_YOU_MEAN"
+				FLAGS="$FLAGS --$DID_YOU_MEAN_FLAG"
+				_install_3rd_party_app
+			fi
+		fi
 	fi
 }
 
@@ -620,26 +638,49 @@ _levenshtein() {
 }
 
 _did_you_mean() {
-	local input="$1"
-	local applist="$AMDATADIR/$ARCH-apps"
-	[ ! -f "$applist" ] && return
-	local names match="" input_len=${#input} first_char="${input:0:1}" best_dist=3 diff dist
-	names=$(grep "^◆ " "$applist" | sed 's/^◆ //;s/ :.*$//')
-	while IFS= read -r name; do
-		[ -z "$name" ] && continue
-		diff=$(( ${#name} - input_len ))
-		[ $diff -lt 0 ] && diff=$(( -diff ))
-		[ $diff -gt 2 ] && continue
-		[ "${name:0:1}" != "$first_char" ] && continue
-		dist=$(_levenshtein "$input" "$name")
-		if [ "$dist" -lt "$best_dist" ]; then
-			best_dist=$dist
-			match=$name
-		fi
-	done <<< "$names"
+	local input="$1" only_flag="$2"
+	local names match="" match_flag="" input_len=${#input} first_char="${input:0:1}" best_dist=3 diff dist
+	DID_YOU_MEAN=""
+	DID_YOU_MEAN_FLAG=""
+
+	_did_you_mean_search() {
+		local list="$1"
+		[ ! -f "$list" ] && return
+		[ "$best_dist" -eq 0 ] && return
+		names=$(grep "^◆ " "$list" | sed 's/^◆ //;s/ :.*$//')
+		while IFS= read -r name; do
+			[ -z "$name" ] && continue
+			[ "$name" = "$input" ] && [ -n "$2" ] && best_dist=0 && match=$name && match_flag="$2" && return
+			diff=$(( ${#name} - input_len ))
+			[ $diff -lt 0 ] && diff=$(( -diff ))
+			[ $diff -gt 2 ] && continue
+			[ "${name:0:1}" != "$first_char" ] && continue
+			dist=$(_levenshtein "$input" "$name")
+			if [ "$dist" -lt "$best_dist" ]; then
+				best_dist=$dist
+				match=$name
+				match_flag="$2"
+			fi
+		done <<< "$names"
+	}
+
+	if [ -n "$only_flag" ]; then
+		_did_you_mean_search "$AMDATADIR/$ARCH-$only_flag" "$only_flag"
+	else
+		_did_you_mean_search "$AMDATADIR/$ARCH-apps" ""
+		for tp_list in $third_party_lists; do
+			_did_you_mean_search "$AMDATADIR/$ARCH-$tp_list" "$tp_list"
+		done
+	fi
+
 	if [ -n "$match" ]; then
-		printf $"\n Did you mean \"%b%b\033[0m\"?\n" "${LightBlue}" "$match"
+		if [ "$best_dist" -eq 0 ] && [ -n "$match_flag" ]; then
+			printf $"\n \"%b%b\033[0m\" is not in the main database, but found in --%b%b\033[0m.\n" "${LightBlue}" "$match" "${LightBlue}" "$match_flag"
+		else
+			printf $"\n Did you mean \"%b%b\033[0m\"?\n" "${LightBlue}" "$match"
+		fi
 		DID_YOU_MEAN="$match"
+		DID_YOU_MEAN_FLAG="$match_flag"
 	fi
 }
 
@@ -738,15 +779,24 @@ case "$1" in
 				_install_normally
 			else
 				echo $"💀 ERROR: \"$arg\" does NOT exist in the \"AM\" database, $(printf "please check the list, run the \"%b$AMCLIPATH_ORIGIN -l\033[0m\" command.\n\n" "${Gold}")" | fold -sw 72 | sed 's/^/ /g'
-				DID_YOU_MEAN=""
 				_did_you_mean "$arg"
 				if [ -n "$DID_YOU_MEAN" ]; then
-					read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
+					if [ -n "$DID_YOU_MEAN_FLAG" ]; then
+						read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
+					else
+						read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
+					fi
 					echo ""
 					if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 						arg="$DID_YOU_MEAN"
-						_prepare_arg
-						_check_and_install
+						if [ -n "$DID_YOU_MEAN_FLAG" ]; then
+							FLAGS="$FLAGS --$DID_YOU_MEAN_FLAG"
+							_prepare_arg
+							_install_3rd_party_app
+						else
+							_prepare_arg
+							_check_and_install
+						fi
 					fi
 				fi
 			fi

--- a/regress/test-am-fuzzy-suggest.sh
+++ b/regress/test-am-fuzzy-suggest.sh
@@ -17,6 +17,8 @@ eval "$(awk '/^_did_you_mean\(\)/,/^}$/' "$_module")"
 # Variables required by _did_you_mean
 AMDATADIR="${AMDATADIR:-$HOME/.local/share/AM}"
 ARCH="${ARCH:-$(uname -m)}"
+LightBlue="${LightBlue:-}"
+third_party_lists="${third_party_lists:-}"
 
 ################################################################################
 # Assertion helpers
@@ -225,6 +227,99 @@ _test_did_you_mean() {
 }
 
 ################################################################################
+# _did_you_mean third-party database tests
+################################################################################
+
+_test_did_you_mean_tp() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	trap 'rm -rf "$tmpdir"' RETURN
+
+	# Fake main app list
+	cat > "$tmpdir/${ARCH}-apps" <<'EOF'
+◆ inkscape : Vector graphics editor
+◆ blender : 3D creation suite
+◆ anydesk : Remote desktop tool
+EOF
+
+	# Fake tp lists
+	cat > "$tmpdir/${ARCH}-busybox" <<'EOF'
+◆ acpid : Listen to ACPI events. To install it use the --busybox flag or the .busybox extension.
+◆ adduser : Add a user to the System. To install it use the --busybox flag or the .busybox extension.
+EOF
+
+	cat > "$tmpdir/${ARCH}-appbundle" <<'EOF'
+◆ xfce4-multicall : Xfce4 multicall binary. To install it use the --appbundle flag or the .appbundle extension.
+◆ xfce4-terminal : Terminal emulator. To install it use the --appbundle flag or the .appbundle extension.
+EOF
+
+	local saved_amdatadir="$AMDATADIR"
+	local saved_tp="$third_party_lists"
+	AMDATADIR="$tmpdir"
+	third_party_lists="busybox appbundle"
+
+	printf "\n=== _did_you_mean third-party tests ===\n"
+	local out
+
+	# Exact match in tp list → special message, flag set
+	out=$(_did_you_mean "xfce4-multicall")
+	_assert_contains "xfce4-multicall exact → mentions app name"       "$out" "xfce4-multicall"
+	_assert_contains "xfce4-multicall exact → mentions appbundle"      "$out" "appbundle"
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	_did_you_mean "xfce4-multicall" > /dev/null
+	_assert_eq "xfce4-multicall exact → DID_YOU_MEAN set"              "$DID_YOU_MEAN" "xfce4-multicall"
+	_assert_eq "xfce4-multicall exact → DID_YOU_MEAN_FLAG=appbundle"   "$DID_YOU_MEAN_FLAG" "appbundle"
+
+	# Exact match in tp list → no "Did you mean" phrase
+	out=$(_did_you_mean "xfce4-multicall")
+	if echo "$out" | grep -q "Did you mean"; then
+		_ko "xfce4-multicall exact → no 'Did you mean' phrase" "(found)" "(absent)"
+	else
+		_ok "xfce4-multicall exact → no 'Did you mean' phrase"
+	fi
+
+	# Fuzzy match in tp list → "Did you mean" + flag
+	out=$(_did_you_mean "acpid2")
+	_assert_contains "acpid2 → suggests acpid"                         "$out" "acpid"
+	_assert_contains "acpid2 → output contains 'Did you mean'"         "$out" "Did you mean"
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	_did_you_mean "acpid2" > /dev/null
+	_assert_eq "acpid2 → DID_YOU_MEAN=acpid"                           "$DID_YOU_MEAN" "acpid"
+	_assert_eq "acpid2 → DID_YOU_MEAN_FLAG=busybox"                    "$DID_YOU_MEAN_FLAG" "busybox"
+
+	# Match in main list wins over tp list (anydesk is in main, not tp)
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	_did_you_mean "amydesk" > /dev/null
+	_assert_eq "amydesk → DID_YOU_MEAN=anydesk (main list)"            "$DID_YOU_MEAN" "anydesk"
+	_assert_eq "amydesk → DID_YOU_MEAN_FLAG empty (main list)"         "$DID_YOU_MEAN_FLAG" ""
+
+	# With only_flag: search restricted to that tp list
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	_did_you_mean "acpid2" "busybox" > /dev/null
+	_assert_eq "acpid2 --busybox → DID_YOU_MEAN=acpid"                 "$DID_YOU_MEAN" "acpid"
+
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	_did_you_mean "acpid2" "appbundle" > /dev/null
+	_assert_empty "acpid2 --appbundle → no match (acpid not in appbundle)" "$DID_YOU_MEAN"
+
+	# Exact match in multiple tp lists → first list wins
+	cat >> "$tmpdir/${ARCH}-appbundle" <<'EOF'
+◆ acpid : Also in appbundle. To install it use the --appbundle flag or the .appbundle extension.
+EOF
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	_did_you_mean "acpid" > /dev/null
+	_assert_eq "acpid in busybox+appbundle → first list (busybox) wins" "$DID_YOU_MEAN_FLAG" "busybox"
+
+	# No match anywhere
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	_did_you_mean "qqqxxx" > /dev/null
+	_assert_empty "qqqxxx → no match in any list" "$DID_YOU_MEAN"
+
+	AMDATADIR="$saved_amdatadir"
+	third_party_lists="$saved_tp"
+}
+
+################################################################################
 # Main
 ################################################################################
 
@@ -232,6 +327,7 @@ _log "Running fuzzy-suggest tests: $0"
 
 _test_levenshtein
 _test_did_you_mean
+_test_did_you_mean_tp
 
 printf "\n=== Results: \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m ===\n\n" "$PASS" "$FAIL"
 printf "Results: %d passed, %d failed\n" "$PASS" "$FAIL" >> "$TEST_LOG"

--- a/regress/test-am-fuzzy-suggest.sh
+++ b/regress/test-am-fuzzy-suggest.sh
@@ -119,7 +119,7 @@ _test_did_you_mean() {
 	printf "\n=== _did_you_mean unit tests ===\n"
 	local out
 
-	# Fast path: extra char(s) at end
+	# Extra char at end
 	out=$(_did_you_mean "zen-browser2")
 	_assert_contains "zen-browser2 → suggests zen-browser"  "$out" "zen-browser"
 	_assert_contains "zen-browser2 → output contains 'Did you mean'" "$out" "Did you mean"
@@ -130,25 +130,25 @@ _test_did_you_mean() {
 	out=$(_did_you_mean "blenders")
 	_assert_contains "blenders → suggests blender"          "$out" "blender"
 
-	# Fast path: missing char at end
+	# Missing char at end
 	out=$(_did_you_mean "inkscap")
 	_assert_contains "inkscap → suggests inkscape"          "$out" "inkscape"
 
 	out=$(_did_you_mean "blende")
 	_assert_contains "blende → suggests blender"            "$out" "blender"
 
-	# Slow path: one wrong char in middle
+	# One wrong char in middle
 	out=$(_did_you_mean "amydesk")
 	_assert_contains "amydesk → suggests anydesk"           "$out" "anydesk"
 
 	out=$(_did_you_mean "audaxity")
 	_assert_contains "audaxity → suggests audacity"         "$out" "audacity"
 
-	# Slow path: transposed chars (distance = 2, within threshold)
+	# Transposed chars (distance = 2, within threshold)
 	out=$(_did_you_mean "inksacpe")
 	_assert_contains "inksacpe → suggests inkscape"         "$out" "inkscape"
 
-	# Slow path: missing char in middle
+	# Missing char in middle
 	out=$(_did_you_mean "blendr")
 	_assert_contains "blendr → suggests blender"            "$out" "blender"
 

--- a/regress/test-am-fuzzy-suggest.sh
+++ b/regress/test-am-fuzzy-suggest.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+# Tests for the fuzzy suggest feature (_levenshtein, _did_you_mean) in modules/install.am
+
+# Source common test functions
+. "$(dirname "$0")/test-common.sh"
+
+TEST_LOG="${TEST_LOG:-test-summary.log}"
+PASS=0
+FAIL=0
+
+# Load the actual functions from the module
+_module="$(dirname "$0")/../modules/install.am"
+eval "$(awk '/^_levenshtein\(\)/,/^}$/' "$_module")"
+eval "$(awk '/^_did_you_mean\(\)/,/^}$/' "$_module")"
+
+# Variables required by _did_you_mean
+AMDATADIR="${AMDATADIR:-$HOME/.local/share/AM}"
+ARCH="${ARCH:-$(uname -m)}"
+
+################################################################################
+# Assertion helpers
+################################################################################
+
+_ok() {
+	printf "  \033[0;32m✔\033[0m  %s\n" "$1"
+	printf "PASS: %s\n" "$1" >> "$TEST_LOG"
+	PASS=$(( PASS + 1 ))
+}
+
+_ko() {
+	printf "  \033[0;31m✘\033[0m  %s\n" "$1"
+	printf "      got:      '%s'\n" "$2"
+	printf "      expected: '%s'\n" "$3"
+	printf "FAIL: %s | got='%s' expected='%s'\n" "$1" "$2" "$3" >> "$TEST_LOG"
+	FAIL=$(( FAIL + 1 ))
+}
+
+_assert_eq() {
+	local label="$1" got="$2" expected="$3"
+	[ "$got" = "$expected" ] && _ok "$label" || _ko "$label" "$got" "$expected"
+}
+
+_assert_contains() {
+	local label="$1" haystack="$2" needle="$3"
+	if echo "$haystack" | grep -q "$needle"; then
+		_ok "$label"
+	else
+		_ko "$label" "(not found)" "$needle"
+	fi
+}
+
+_assert_empty() {
+	local label="$1" value="$2"
+	[ -z "$value" ] && _ok "$label" || _ko "$label" "$value" "(empty)"
+}
+
+################################################################################
+# _levenshtein unit tests
+################################################################################
+
+_test_levenshtein() {
+	printf "\n=== _levenshtein unit tests ===\n"
+
+	# Trivial cases
+	_assert_eq "identical strings → 0"            "$(_levenshtein 'abc' 'abc')"       0
+	_assert_eq "empty vs empty → 0"               "$(_levenshtein '' '')"              0
+	_assert_eq "empty vs string → string length"  "$(_levenshtein '' 'hello')"         5
+	_assert_eq "string vs empty → string length"  "$(_levenshtein 'hello' '')"         5
+	_assert_eq "single char same → 0"             "$(_levenshtein 'x' 'x')"            0
+	_assert_eq "single char diff → 1"             "$(_levenshtein 'x' 'y')"            1
+
+	# One edit
+	_assert_eq "one substitution (cat→bat) → 1"   "$(_levenshtein 'cat' 'bat')"        1
+	_assert_eq "one insertion (cat→cats) → 1"     "$(_levenshtein 'cat' 'cats')"       1
+	_assert_eq "one deletion (cats→cat) → 1"      "$(_levenshtein 'cats' 'cat')"       1
+
+	# Classic test vectors
+	_assert_eq "kitten→sitting → 3"               "$(_levenshtein 'kitten' 'sitting')" 3
+	_assert_eq "sunday→saturday → 3"              "$(_levenshtein 'sunday' 'saturday')" 3
+	_assert_eq "abc→xyz (full replace) → 3"       "$(_levenshtein 'abc' 'xyz')"         3
+
+	# Case-sensitivity
+	_assert_eq "case-sensitive: abc≠Abc → 1"      "$(_levenshtein 'abc' 'Abc')"         1
+	_assert_eq "case-sensitive: abc≠ABC → 3"      "$(_levenshtein 'abc' 'ABC')"         3
+
+	# Realistic app-name typos
+	_assert_eq "amydesk→anydesk (1 subst) → 1"       "$(_levenshtein 'amydesk' 'anydesk')"     1
+	_assert_eq "inkscap→inkscape (1 del) → 1"         "$(_levenshtein 'inkscap' 'inkscape')"    1
+	_assert_eq "zen-browser2→zen-browser (1 del) → 1" "$(_levenshtein 'zen-browser2' 'zen-browser')" 1
+	_assert_eq "audaxity→audacity (1 subst) → 1"      "$(_levenshtein 'audaxity' 'audacity')"   1
+	_assert_eq "inksacpe→inkscape (2 subst) → 2"      "$(_levenshtein 'inksacpe' 'inkscape')"   2
+	_assert_eq "blenders→blender (1 ins) → 1"         "$(_levenshtein 'blenders' 'blender')"    1
+	_assert_eq "blendr→blender (1 del) → 1"           "$(_levenshtein 'blendr' 'blender')"      1
+
+	# Short app names (2–4 chars)
+	_assert_eq "gim→gimp (1 del) → 1"    "$(_levenshtein 'gim' 'gimp')"   1
+	_assert_eq "batt→bat (1 ins) → 1"    "$(_levenshtein 'batt' 'bat')"   1
+	_assert_eq "fdd→fd (1 ins) → 1"      "$(_levenshtein 'fdd' 'fd')"     1
+	_assert_eq "ghh→gh (1 ins) → 1"      "$(_levenshtein 'ghh' 'gh')"     1
+	_assert_eq "jqq→jq (1 ins) → 1"      "$(_levenshtein 'jqq' 'jq')"     1
+	_assert_eq "nvimm→nvim (1 ins) → 1"  "$(_levenshtein 'nvimm' 'nvim')" 1
+	_assert_eq "viim→vifm (1 subst) → 1" "$(_levenshtein 'viim' 'vifm')"  1
+	_assert_eq "bat→bat (exact) → 0"     "$(_levenshtein 'bat' 'bat')"    0
+}
+
+################################################################################
+# _did_you_mean unit tests (require cached app list)
+################################################################################
+
+_test_did_you_mean() {
+	local applist="${AMDATADIR:-$HOME/.local/share/AM}/${ARCH:-$(uname -m)}-apps"
+	if [ ! -f "$applist" ]; then
+		printf "\n=== _did_you_mean tests SKIPPED (no cached app list at %s) ===\n" "$applist"
+		printf "SKIP: _did_you_mean tests — no app list cached\n" >> "$TEST_LOG"
+		return
+	fi
+
+	printf "\n=== _did_you_mean unit tests ===\n"
+	local out
+
+	# Fast path: extra char(s) at end
+	out=$(_did_you_mean "zen-browser2")
+	_assert_contains "zen-browser2 → suggests zen-browser"  "$out" "zen-browser"
+	_assert_contains "zen-browser2 → output contains 'Did you mean'" "$out" "Did you mean"
+
+	out=$(_did_you_mean "inkscape1")
+	_assert_contains "inkscape1 → suggests inkscape"        "$out" "inkscape"
+
+	out=$(_did_you_mean "blenders")
+	_assert_contains "blenders → suggests blender"          "$out" "blender"
+
+	# Fast path: missing char at end
+	out=$(_did_you_mean "inkscap")
+	_assert_contains "inkscap → suggests inkscape"          "$out" "inkscape"
+
+	out=$(_did_you_mean "blende")
+	_assert_contains "blende → suggests blender"            "$out" "blender"
+
+	# Slow path: one wrong char in middle
+	out=$(_did_you_mean "amydesk")
+	_assert_contains "amydesk → suggests anydesk"           "$out" "anydesk"
+
+	out=$(_did_you_mean "audaxity")
+	_assert_contains "audaxity → suggests audacity"         "$out" "audacity"
+
+	# Slow path: transposed chars (distance = 2, within threshold)
+	out=$(_did_you_mean "inksacpe")
+	_assert_contains "inksacpe → suggests inkscape"         "$out" "inkscape"
+
+	# Slow path: missing char in middle
+	out=$(_did_you_mean "blendr")
+	_assert_contains "blendr → suggests blender"            "$out" "blender"
+
+	# Short app names (2–4 chars): extra char, missing char, wrong char
+	out=$(_did_you_mean "gim")
+	_assert_contains "gim → suggests gimp"    "$out" "gimp"
+
+	out=$(_did_you_mean "nvimm")
+	_assert_contains "nvimm → suggests nvim"  "$out" "nvim"
+
+	out=$(_did_you_mean "fdd")
+	_assert_contains "fdd → suggests fd"      "$out" "fd"
+
+	out=$(_did_you_mean "ghh")
+	_assert_contains "ghh → suggests gh"      "$out" "gh"
+
+	out=$(_did_you_mean "jqq")
+	_assert_contains "jqq → suggests jq"      "$out" "jq"
+
+	out=$(_did_you_mean "viim")
+	_assert_contains "viim → suggests vifm"   "$out" "vifm"
+
+	out=$(_did_you_mean "batt")
+	_assert_contains "batt → suggests bat"    "$out" "bat"
+
+	# Separator variants: dash omitted, replaced with underscore or space
+	out=$(_did_you_mean "zenbrowser")
+	_assert_contains "zenbrowser (no dash) → suggests zen-browser"          "$out" "zen-browser"
+
+	out=$(_did_you_mean "zen_browser")
+	_assert_contains "zen_browser (underscore) → suggests zen-browser"      "$out" "zen-browser"
+
+	out=$(_did_you_mean "zen browser")
+	_assert_contains "zen browser (space) → suggests zen-browser"           "$out" "zen-browser"
+
+	out=$(_did_you_mean "openvideodownloader")
+	_assert_contains "openvideodownloader (no dashes) → suggests open-video-downloader" "$out" "open-video-downloader"
+
+	out=$(_did_you_mean "openvideo-downloader")
+	_assert_contains "openvideo-downloader (dash shifted) → suggests open-video-downloader" "$out" "open-video-downloader"
+
+	out=$(_did_you_mean "open-videodownloader")
+	_assert_contains "open-videodownloader (dash shifted) → suggests open-video-downloader" "$out" "open-video-downloader"
+
+	out=$(_did_you_mean "lossless-cut")
+	_assert_contains "lossless-cut (extra dash) → suggests losslesscut"     "$out" "losslesscut"
+
+	out=$(_did_you_mean "lossless_cut")
+	_assert_contains "lossless_cut (underscore) → suggests losslesscut"     "$out" "losslesscut"
+
+	# Suggestion format: output must include 'Did you mean' phrase
+	out=$(_did_you_mean "amydesk")
+	_assert_contains "suggestion includes 'Did you mean' text" "$out" "Did you mean"
+
+	# DID_YOU_MEAN variable is set on match, empty on no match
+	DID_YOU_MEAN=""
+	_did_you_mean "amydesk" > /dev/null
+	_assert_eq "DID_YOU_MEAN set to anydesk on match"    "$DID_YOU_MEAN" "anydesk"
+
+	DID_YOU_MEAN=""
+	_did_you_mean "zzzznotanapp" > /dev/null
+	_assert_empty "DID_YOU_MEAN empty on no match"       "$DID_YOU_MEAN"
+
+	# No suggestion: completely unrelated string
+	out=$(_did_you_mean "zzzznotanapp")
+	_assert_empty "zzzznotanapp → no suggestion"            "$out"
+
+	# No suggestion: string too different from any app (distance > threshold)
+	out=$(_did_you_mean "qqqxxx")
+	_assert_empty "qqqxxx (no app within edit-distance 2) → no suggestion" "$out"
+
+	out=$(_did_you_mean "anydesk")
+	_assert_contains "anydesk (exact DB name) → still finds the app" "$out" "anydesk"
+}
+
+################################################################################
+# Main
+################################################################################
+
+_log "Running fuzzy-suggest tests: $0"
+
+_test_levenshtein
+_test_did_you_mean
+
+printf "\n=== Results: \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m ===\n\n" "$PASS" "$FAIL"
+printf "Results: %d passed, %d failed\n" "$PASS" "$FAIL" >> "$TEST_LOG"
+
+[ "$FAIL" -gt 0 ] && _fail "$FAIL test(s) failed."
+_pass

--- a/translations/po-files/cs.po
+++ b/translations/po-files/cs.po
@@ -1545,6 +1545,14 @@ msgstr ""
 "the list, run the \\\"%b$AMCLIPATH_ORIGIN -l\\033[0m\\\" command.\\n\\n\" "
 "\"${Gold}\")"
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
+msgstr "\\n Mysleli jste \\"%b%b\\033[0m\\"?\\n"
+
+#: modules/install.am:727
+msgid " Install \\"$DID_YOU_MEAN\\" instead? (Y/n) "
+msgstr " Nainstalovat \"$DID_YOU_MEAN\" místo toho? (Y/n) "
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr "\\n CHYBA: \\\"%b\\\" NENÍ AppImage\\n"

--- a/translations/po-files/cs.po
+++ b/translations/po-files/cs.po
@@ -1546,6 +1546,13 @@ msgstr ""
 "\"${Gold}\")"
 
 #: modules/install.am:620
+
+msgid "\\n \\"%b%b\\033[0m\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr "\\n \\"%b%b\\033[0m\\" není v hlavní databázi, ale nalezen v --%b%b\\033[0m.\\n"
+
+msgid " Install \\"$DID_YOU_MEAN\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr " Nainstalovat \\"$DID_YOU_MEAN\\" s příznakem --$DID_YOU_MEAN_FLAG? (Y/n) "
+
 msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
 msgstr "\\n Mysleli jste \\"%b%b\\033[0m\\"?\\n"
 

--- a/translations/po-files/de.po
+++ b/translations/po-files/de.po
@@ -1759,6 +1759,14 @@ msgstr ""
 "$(printf \"bitte prüfen Sie die Liste, führen Sie den Befehl \\"
 "\"%b$AMCLIPATH_ORIGIN -l\\033[0m\\\" aus.\\n\\n\" \"${Gold}\")"
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
+msgstr "\\n Meinten Sie \\"%b%b\\033[0m\\"?\\n"
+
+#: modules/install.am:727
+msgid " Install \\"$DID_YOU_MEAN\\" instead? (Y/n) "
+msgstr " Stattdessen \"$DID_YOU_MEAN\" installieren? (Y/n) "
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr "\\n FEHLER: \\\"%b\\\" ist KEIN AppImage\\n"

--- a/translations/po-files/de.po
+++ b/translations/po-files/de.po
@@ -1760,6 +1760,13 @@ msgstr ""
 "\"%b$AMCLIPATH_ORIGIN -l\\033[0m\\\" aus.\\n\\n\" \"${Gold}\")"
 
 #: modules/install.am:620
+
+msgid "\\n \\"%b%b\\033[0m\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr "\\n \\"%b%b\\033[0m\\" ist nicht in der Hauptdatenbank, aber in --%b%b\\033[0m gefunden.\\n"
+
+msgid " Install \\"$DID_YOU_MEAN\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr " \\"$DID_YOU_MEAN\\" mit dem Flag --$DID_YOU_MEAN_FLAG installieren? (Y/n) "
+
 msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
 msgstr "\\n Meinten Sie \\"%b%b\\033[0m\\"?\\n"
 

--- a/translations/po-files/es.po
+++ b/translations/po-files/es.po
@@ -1572,6 +1572,14 @@ msgstr ""
 "\"por favor, compruebe la lista, ejecute el comando \\\"%b$AMCLIPATH_ORIGIN -"
 "l\\033[0m\\\".\\n\\n\" \"${Gold}\")"
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
+msgstr "\\n ¿Quiso decir \\"%b%b\\033[0m\\"?\\n"
+
+#: modules/install.am:727
+msgid " Install \\"$DID_YOU_MEAN\\" instead? (Y/n) "
+msgstr " ¿Instalar \"$DID_YOU_MEAN\" en su lugar? (S/n) "
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr "\\n ERROR: \\\"%b\\\" NO es una AppImage\\n"

--- a/translations/po-files/es.po
+++ b/translations/po-files/es.po
@@ -1573,6 +1573,13 @@ msgstr ""
 "l\\033[0m\\\".\\n\\n\" \"${Gold}\")"
 
 #: modules/install.am:620
+
+msgid "\\n \\"%b%b\\033[0m\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr "\\n \\"%b%b\\033[0m\\" no está en la base de datos principal, pero se encontró en --%b%b\\033[0m.\\n"
+
+msgid " Install \\"$DID_YOU_MEAN\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr " ¿Instalar \\"$DID_YOU_MEAN\\" con el indicador --$DID_YOU_MEAN_FLAG? (S/n) "
+
 msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
 msgstr "\\n ¿Quiso decir \\"%b%b\\033[0m\\"?\\n"
 

--- a/translations/po-files/it.po
+++ b/translations/po-files/it.po
@@ -1775,6 +1775,13 @@ msgstr ""
 "l\\033[0m\\\".\\n\\n\" \"${Gold}\")"
 
 #: modules/install.am:620
+
+msgid "\\n \\"%b%b\\033[0m\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr "\\n \\"%b%b\\033[0m\\" non è nel database principale, ma trovato in --%b%b\\033[0m.\\n"
+
+msgid " Install \\"$DID_YOU_MEAN\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr " Installare \\"$DID_YOU_MEAN\\" con il flag --$DID_YOU_MEAN_FLAG? (Y/n) "
+
 msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
 msgstr "\\n Forse intendevi \\"%b%b\\033[0m\\"?\\n"
 

--- a/translations/po-files/it.po
+++ b/translations/po-files/it.po
@@ -1774,6 +1774,14 @@ msgstr ""
 "\"per favore controlla l'elenco, esegui il comando \\\"%b$AMCLIPATH_ORIGIN -"
 "l\\033[0m\\\".\\n\\n\" \"${Gold}\")"
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
+msgstr "\\n Forse intendevi \\"%b%b\\033[0m\\"?\\n"
+
+#: modules/install.am:727
+msgid " Install \\"$DID_YOU_MEAN\\" instead? (Y/n) "
+msgstr " Installare \"$DID_YOU_MEAN\" al suo posto? (Y/n) "
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr "\\n ERRORE: \\\"%b\\\" NON è un'AppImage\\n"

--- a/translations/po-files/pt_BR.po
+++ b/translations/po-files/pt_BR.po
@@ -1772,6 +1772,14 @@ msgstr ""
 "\"por favor, verifique a lista, execute o \\\"%b$AMCLIPATH_ORIGIN -"
 "l\\033[0m\\\" comando.\\n\\n\" \"${Gold}\")"
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
+msgstr "\\n Você quis dizer \\"%b%b\\033[0m\\"?\\n"
+
+#: modules/install.am:727
+msgid " Install \\"$DID_YOU_MEAN\\" instead? (Y/n) "
+msgstr " Instalar \"$DID_YOU_MEAN\" em vez disso? (Y/n) "
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr "\\n ERRO: \\\"%b\\\" NÃO é um AppImage\\n"

--- a/translations/po-files/pt_BR.po
+++ b/translations/po-files/pt_BR.po
@@ -1773,6 +1773,13 @@ msgstr ""
 "l\\033[0m\\\" comando.\\n\\n\" \"${Gold}\")"
 
 #: modules/install.am:620
+
+msgid "\\n \\"%b%b\\033[0m\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr "\\n \\"%b%b\\033[0m\\" não está no banco de dados principal, mas encontrado em --%b%b\\033[0m.\\n"
+
+msgid " Install \\"$DID_YOU_MEAN\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr " Instalar \\"$DID_YOU_MEAN\\" com a flag --$DID_YOU_MEAN_FLAG? (Y/n) "
+
 msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
 msgstr "\\n Você quis dizer \\"%b%b\\033[0m\\"?\\n"
 

--- a/translations/po-files/ru.po
+++ b/translations/po-files/ru.po
@@ -1734,6 +1734,13 @@ msgstr ""
 "\\n\\n\" \"${Gold}\")"
 
 #: modules/install.am:620
+
+msgid "\\n \\"%b%b\\033[0m\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr "\\n \\"%b%b\\033[0m\\" не найден в основной базе данных, но найден в --%b%b\\033[0m.\\n"
+
+msgid " Install \\"$DID_YOU_MEAN\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr " Установить \\"$DID_YOU_MEAN\\" с флагом --$DID_YOU_MEAN_FLAG? (Y/n) "
+
 msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
 msgstr "\\n Возможно, вы имели в виду \\"%b%b\\033[0m\\"?\\n"
 

--- a/translations/po-files/ru.po
+++ b/translations/po-files/ru.po
@@ -1733,6 +1733,14 @@ msgstr ""
 "\"проверьте список, выполните команду \\\"%b$AMCLIPATH_ORIGIN -l\\033[0m\\\"."
 "\\n\\n\" \"${Gold}\")"
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
+msgstr "\\n Возможно, вы имели в виду \\"%b%b\\033[0m\\"?\\n"
+
+#: modules/install.am:727
+msgid " Install \\"$DID_YOU_MEAN\\" instead? (Y/n) "
+msgstr " Установить \"$DID_YOU_MEAN\" вместо этого? (Y/n) "
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr "\\n ОШИБКА: \\\"%b\\\" не AppImage\\n"

--- a/translations/po-files/sr.po
+++ b/translations/po-files/sr.po
@@ -1747,6 +1747,14 @@ msgstr ""
 "\"molim proveri listu, pokreni \\\"%b$AMCLIPATH_ORIGIN -l\\033[0m\\\" "
 "komandu.\\n\\n\" \"${Gold}\")"
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
+msgstr "\\n Да ли сте мислили на \\"%b%b\\033[0m\\"?\\n"
+
+#: modules/install.am:727
+msgid " Install \\"$DID_YOU_MEAN\\" instead? (Y/n) "
+msgstr " Инсталирати \"$DID_YOU_MEAN\" уместо тога? (Y/n) "
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr "\\n GREŠKA: \\\"%b\\\" NIJE AppImage\\n"

--- a/translations/po-files/sr.po
+++ b/translations/po-files/sr.po
@@ -1748,6 +1748,13 @@ msgstr ""
 "komandu.\\n\\n\" \"${Gold}\")"
 
 #: modules/install.am:620
+
+msgid "\\n \\"%b%b\\033[0m\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr "\\n \\"%b%b\\033[0m\\" није у главној бази података, али је пронађен у --%b%b\\033[0m.\\n"
+
+msgid " Install \\"$DID_YOU_MEAN\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr " Инсталирати \\"$DID_YOU_MEAN\\" са заставицом --$DID_YOU_MEAN_FLAG? (Y/n) "
+
 msgid "\\n Did you mean \\"%b%b\\033[0m\\"?\\n"
 msgstr "\\n Да ли сте мислили на \\"%b%b\\033[0m\\"?\\n"
 

--- a/translations/source.po
+++ b/translations/source.po
@@ -1473,6 +1473,14 @@ msgid ""
 "command.\\n\\n\" \"${Gold}\")"
 msgstr ""
 
+#: modules/install.am:620
+msgid "\\n Did you mean \\\"%b%b\\033[0m\\\"?\\n"
+msgstr ""
+
+#: modules/install.am:727
+msgid " Install \\\"$DID_YOU_MEAN\\\" instead? (Y/n) "
+msgstr ""
+
 #: modules/install.am:694
 msgid "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr ""

--- a/translations/source.po
+++ b/translations/source.po
@@ -1473,11 +1473,19 @@ msgid ""
 "command.\\n\\n\" \"${Gold}\")"
 msgstr ""
 
-#: modules/install.am:620
+#: modules/install.am:677
+msgid "\\n \\\"%b%b\\033[0m\\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr ""
+
+#: modules/install.am:679
 msgid "\\n Did you mean \\\"%b%b\\033[0m\\\"?\\n"
 msgstr ""
 
-#: modules/install.am:727
+#: modules/install.am:581 modules/install.am:784
+msgid " Install \\\"$DID_YOU_MEAN\\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr ""
+
+#: modules/install.am:583 modules/install.am:786
 msgid " Install \\\"$DID_YOU_MEAN\\\" instead? (Y/n) "
 msgstr ""
 

--- a/translations/source.pot
+++ b/translations/source.pot
@@ -1255,11 +1255,19 @@ msgstr  ""
 msgid   "💀 ERROR: \\\"$arg\\\" does NOT exist in the \\\"AM\\\" database, $(printf \"please check the list, run the \\\"%b$AMCLIPATH_ORIGIN -l\\033[0m\\\" command.\\n\\n\" \"${Gold}\")"
 msgstr  ""
 
-#: modules/install.am:620
+#: modules/install.am:677
+msgid   "\\n \\\"%b%b\\033[0m\\\" is not in the main database, but found in --%b%b\\033[0m.\\n"
+msgstr  ""
+
+#: modules/install.am:679
 msgid   "\\n Did you mean \\\"%b%b\\033[0m\\\"?\\n"
 msgstr  ""
 
-#: modules/install.am:727
+#: modules/install.am:581 modules/install.am:784
+msgid   " Install \\\"$DID_YOU_MEAN\\\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) "
+msgstr  ""
+
+#: modules/install.am:583 modules/install.am:786
 msgid   " Install \\\"$DID_YOU_MEAN\\\" instead? (Y/n) "
 msgstr  ""
 

--- a/translations/source.pot
+++ b/translations/source.pot
@@ -1255,6 +1255,14 @@ msgstr  ""
 msgid   "💀 ERROR: \\\"$arg\\\" does NOT exist in the \\\"AM\\\" database, $(printf \"please check the list, run the \\\"%b$AMCLIPATH_ORIGIN -l\\033[0m\\\" command.\\n\\n\" \"${Gold}\")"
 msgstr  ""
 
+#: modules/install.am:620
+msgid   "\\n Did you mean \\\"%b%b\\033[0m\\\"?\\n"
+msgstr  ""
+
+#: modules/install.am:727
+msgid   " Install \\\"$DID_YOU_MEAN\\\" instead? (Y/n) "
+msgstr  ""
+
 #: modules/install.am:694
 msgid   "\\n ERROR: \\\"%b\\\" is NOT an AppImage\\n"
 msgstr  ""


### PR DESCRIPTION
When a user types a wrong app name, AM now shows "Did you mean X?" and offers a Y/n prompt to install the correct app automatically.

Uses Levenshtein edit distance to find the closest match in the app database. Filtering by first character and length difference keeps the search fast across 3200+ entries.

<img width="636" height="270" alt="Screenshot_20260520_134327" src="https://github.com/user-attachments/assets/7422036e-db24-46e6-ae91-ba565c69fd62" />
