### PR TITLE
Remove "-appimage" suffix from appnames

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -27,9 +27,6 @@ _about_status() {
 	done
 	# Determine status using script names
 	if echo "$SCRIPTNAMES" | grep -q "^$arg$"; then
-		if ! echo "$ARGPATHS" | grep -q "/$appname$"; then
-			appname=$(echo "$appname" | sed -- 's/-appimage$//g')
-		fi
 		argpath_items=$(echo "$ARGPATHS" | grep "/$arg$" | xargs)
 		for argpath in $argpath_items; do
 			if [ -n "$argpath" ]; then

--- a/modules/install.am
+++ b/modules/install.am
@@ -412,14 +412,7 @@ _install_appimage() {
 		if grep -q "^◆ $arg : " "$AMDATADIR/$ARCH-appimages"; then
 			echo "$arg" >> "$AMCACHEDIR"/install-args
 		else
-			arg="$arg-appimage"
-			if ! grep -q "^◆ $arg : " "$AMDATADIR/$ARCH-appimages"; then
-				echo "$DIVIDING_LINE"
-				echo $" ✖ \"$(echo "$arg" | sed 's/-appimage//g')\" is not an Appimage"
-				echo "$DIVIDING_LINE"
-			else
-				echo "$arg" >> "$AMCACHEDIR"/install-args
-			fi
+			printf $"%b\n ERROR: \"%b\" is NOT an AppImage\n%b\n" "$DIVIDING_LINE" "$arg" "$DIVIDING_LINE"
 		fi
 	done
 	entries=$(cat "$AMCACHEDIR"/install-args 2>/dev/null)
@@ -598,9 +591,8 @@ _install_3rd_party_app() {
 
 _prepare_arg() {
 	arg_origin="$arg"
-	pure_arg=$(echo "$arg" | sed 's/\-appimage$//g' | sed 's:.*/::')
+	pure_arg=$(echo "$arg" | sed 's:.*/::')
 	_remove_extensions_from_appname
-	echo "$arg" | grep -q -- "-appimage$" && _use_online_reading_tool "$APPSDB"/"$arg" | grep -q "APP=.*-appimage$" && pure_arg="$arg"
 }
 
 _check_and_install() {
@@ -817,7 +809,7 @@ case "$1" in
 						fi
 					fi
 				else
-					printf $"\n ERROR: \"%b\" is NOT an AppImage\n" "$LASTDIR"
+					printf $"%b\n ERROR: \"%b\" is NOT an AppImage\n%b\n" "$DIVIDING_LINE" "$LASTDIR" "$DIVIDING_LINE"
 				fi
 			fi
 			echo "____________________________________________________________________________"

--- a/templates/AM-SAMPLE-AppImage-muliple-choices-Archive+AppImage
+++ b/templates/AM-SAMPLE-AppImage-muliple-choices-Archive+AppImage
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=SAMPLE
+SITE="DOMAIN/REPOSITORY" SITE2="DOMAIN/REPOSITORY"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP
+read -r -p "
+ Choose a package format:
+
+ 1. Official portable package.
+
+    Source: $SITE
+
+ 2. Unofficial AppImage.
+
+    Source: $SITE2
+
+ Which version you choose (type a number and press ENTER)?" response
+RELEASE=""
+
+if echo "$response" | grep -q "^1"; then
+	RELEASE="PORTABLE"
+	version=$(FUNCTION)
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	mv ./tmp/*/* ./ 2>/dev/null || mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./
+elif echo "$response" | grep -q "^2"; then
+	RELEASE="APPIMAGE"
+	version=$(FUNCTION)
+	wget "$version" || exit 1
+	cd ..
+	mv ./tmp/*mage ./"$APP"
+fi
+[ -z "$RELEASE" ] && exit 0
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+if [ "$RELEASE" = APPIMAGE ]; then
+	# SCRIPT TO UPDATE THE PROGRAM
+	cat <<-'HEREDOC' >> ./AM-updater
+	#!/bin/sh
+	set -u
+	APP=SAMPLE
+	SITE="DOMAIN/REPOSITORY"
+	version0=$(cat "/opt/$APP/version")
+	version=$(FUNCTION)
+	[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+	if command -v appimageupdatetool >/dev/null 2>&1; then
+	   cd "/opt/$APP" || exit 1
+	   appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+	fi
+	if [ "$version" != "$version0" ]; then
+	   mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	   notify-send "A new version of $APP is available, please wait"
+	   wget "$version" || exit 1
+	   # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	   cd ..
+	   mv --backup=t ./tmp/*mage ./"$APP"
+	   chmod a+x ./"$APP" || exit 1
+	   echo "$version" > ./version
+	   rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	   notify-send "$APP is updated!"
+	else
+	   echo "Update not needed!"
+	fi
+	HEREDOC
+	chmod a+x ./AM-updater || exit 1
+
+	# LAUNCHER & ICON
+	./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+	./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+	COUNT=0
+	while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+		if [ -L ./"$APP".desktop ]; then
+			LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
+			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+		fi
+		if [ -L ./DirIcon ]; then
+			LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+		fi
+		[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+		COUNT=$((COUNT + 1))
+	done
+	sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./"$APP".desktop
+	mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+	rm -R -f ./squashfs-root
+else
+	# SCRIPT TO UPDATE THE PROGRAM
+	cat <<-'HEREDOC' >> ./AM-updater
+	#!/bin/sh
+	set -u
+	APP=SAMPLE
+	SITE="DOMAIN/REPOSITORY"
+	version0=$(cat "/opt/$APP/version")
+	version=$(FUNCTION)
+	[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+	if [ "$version" != "$version0" ]; then
+	   mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	   notify-send "A new version of $APP is available, please wait"
+	   wget "$version" || exit 1
+	   [ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	   [ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	   [ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	   cd ..
+	   mv ./tmp/*/* ./ 2>/dev/null || mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./
+	   chmod a+x ./"$APP" || exit 1
+	   echo "$version" > ./version
+	   rm -R -f ./tmp ./*~
+	   notify-send "$APP is updated!"
+	else
+	   echo "Update not needed!"
+	fi
+	HEREDOC
+	chmod a+x ./AM-updater || exit 1
+
+	# ICON
+	mkdir -p icons
+	curl -s -Lo ./icons/"$APP" https://portable-linux-apps.github.io/icons/"$APP".png
+
+	# LAUNCHER
+	rm -f /usr/local/share/applications/"$APP"-AM.desktop
+	cat <<-HEREDOC >> /usr/local/share/applications/"$APP"-AM.desktop
+	[Desktop Entry]
+
+	DESKTOP FILE, BUT WITH FOLLOWING PARAMETHERS:
+
+	Exec=$APP %f
+	Icon=/opt/$APP/icons/$APP
+
+	HEREDOC
+fi


### PR DESCRIPTION
Scripts that explicitly declare to be AppImages in the name (by ending with "-appimage") are no more allowed.

From now on only pure names are allowed.

In case applications require double format, use a multi choose script template, or overwrite the existing one (AppImages are recommended).

NEW template available: **AM-SAMPLE-AppImage-muliple-choices-Archive+AppImage**