### PR TITLE
Add --restore-desktop option to reset a modified .desktop file

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -950,10 +950,10 @@ fi
 
 # COMPLETION LIST
 available_options="about add apikey backup clean clone config disable downgrade download enable extra files hide home icons info \
-	install install-appimage integrate launcher list lock neodb newrepo nolibfuse off on overwrite purge query reinstall relocate remove sandbox \
+	install install-appimage integrate launcher list lock neodb newrepo nolibfuse off on overwrite purge query reinstall relocate remove restore-desktop sandbox \
 	search select sync template test translate unhide unlock update upgrade --all --appimages --apps --byname --clone --config --convert --debug \
 	--devmode-disable --devmode-enable --disable-notifications --enable-notifications --force-latest --help --home --icons \
-	-ias --launcher --less --pkg --portable --rollback --disable-sandbox --relocate --sandbox --system --translate --user $third_party_flags"
+	-ias --launcher --less --pkg --portable --restore-desktop --rollback --disable-sandbox --relocate --sandbox --system --translate --user $third_party_flags"
 
 _completion_lists() {
 	# Remove existing lists and download new ones
@@ -2185,7 +2185,8 @@ case "$1" in
 	'lock'|'unlock'|\
 	'nolibfuse'|\
 	'overwrite'|'-o'|\
-	'remove'|'-R'|'-r')
+	'remove'|'-R'|'-r'|\
+	'restore-desktop'|'--restore-desktop')
 		MODULE="management.am"
 		_use_module "$@"
 		;;

--- a/docs/guides-and-tutorials/launcher.md
+++ b/docs/guides-and-tutorials/launcher.md
@@ -81,6 +81,24 @@ Again, **these updates only work if the AppImage supports binary deltas**!
 
 If you want to be sure to update all AppImages, rely on the [`-ia`](./install-appimage.md) and [`-e`](./extra.md) options instead.
 
+---------------------------
+### Restore a modified .desktop file
+The `--restore-desktop` (alias `restore-desktop`) option resets an installed app's `.desktop` launcher to the snapshot that was captured at install time. Use it if you (or the app itself) modified the live `.desktop` file — for example by adding `Name=Emacs (appman)` to distinguish two installs — and you want to roll the change back without reinstalling.
+```
+am --restore-desktop $APPNAME
+```
+or
+```
+appman --restore-desktop $APPNAME
+```
+You can pass several apps at once:
+```
+am --restore-desktop firefox brave thunderbird
+```
+The snapshot is created by the `-i` install option and stored at `$APPDIR/.am-installer/$APPNAME-AM.desktop.orig`, alongside the cached install script. It captures the `.desktop` *after* any post-install patches the install script applies (e.g. the `StartupWMClass` line added by `google-chrome`), so restoring brings back the state AM originally installed — not the raw upstream copy from inside the AppImage.
+
+If no snapshot exists yet (apps installed before this feature was added), the option will print an error pointing you at `-i` to recreate one by reinstalling.
+
 ------------------------------------------------------------------------
 
 | [Back to "Guides and tutorials"](../../README.md#guides-and-tutorials) | [Back to "Main Index"](../../README.md#main-index) | ["Portable Linux Apps"](https://portable-linux-apps.github.io/) | [ "AppMan" ](https://github.com/ivan-hc/AppMan) |

--- a/modules/install.am
+++ b/modules/install.am
@@ -221,6 +221,17 @@ _post_installation_processes() {
 			sed -i "s#Exec=/opt/#Exec=$BINDIR/#g" "$a" 2>/dev/null
 		done
 	fi
+	# Snapshot the final .desktop file so it can be restored later with
+	# "$AMCLI --restore-desktop $arg" if the user (or the launcher itself)
+	# modifies the live copy. Taken after the patch block above so the
+	# snapshot matches what AM actually installed, not the raw upstream
+	# .desktop from inside the AppImage.
+	if [ -f "${LASTDIRPATH}"/remove ] && [ -d "${LASTDIRPATH}"/.am-installer ]; then
+		desktop_src=$(grep -Eo "/[^[:space:]\"']*AM\.desktop" "${LASTDIRPATH}"/remove 2>/dev/null | head -1)
+		if [ -n "$desktop_src" ] && [ -f "$desktop_src" ]; then
+			cp "$desktop_src" "${LASTDIRPATH}"/.am-installer/"$arg"-AM.desktop.orig 2>/dev/null
+		fi
+	fi
 	# Export all icons for hicolor theme usage
 	if echo "$FLAGS" | grep -q -- '--icons'; then
 		_icon_theme_export_to_datadir 2>/dev/null

--- a/modules/management.am
+++ b/modules/management.am
@@ -389,6 +389,46 @@ _launcher(){
 }
 
 ################################################################################################################################################################
+#				RESTORE-DESKTOP
+################################################################################################################################################################
+
+# Restore an app's .desktop file from the snapshot saved at install time.
+# The snapshot is created by _post_installation_processes in install.am and
+# lives at $argpath/.am-installer/$arg-AM.desktop.orig. The live .desktop
+# path is read from the app's `remove` script (it always contains an
+# absolute path matching "*AM.desktop").
+_restore_desktop() {
+	backup="$argpath/.am-installer/$arg-AM.desktop.orig"
+	if [ ! -f "$argpath"/remove ]; then
+		printf $" 💀 ERROR: \"%s\" is not a managed install (no remove script).\n" "$arg"
+		return 1
+	fi
+	if [ ! -f "$backup" ]; then
+		printf $" 💀 ERROR: no .desktop snapshot for \"%s\".\n" "$arg"
+		printf $"    Snapshots are taken at install time; reinstall with \"%s -i %s\" to create one.\n" "$AMCLI" "$arg"
+		return 1
+	fi
+	desktop_path=$(grep -Eo "/[^[:space:]\"']*AM\.desktop" "$argpath"/remove 2>/dev/null | head -1)
+	if [ -z "$desktop_path" ]; then
+		printf $" 💀 ERROR: could not determine the .desktop path for \"%s\".\n" "$arg"
+		return 1
+	fi
+	# System paths (/usr/local/share/applications) need root; user paths
+	# (~/.local/share/applications) do not. Try unprivileged first.
+	if cp "$backup" "$desktop_path" 2>/dev/null \
+		|| $SUDOCMD cp "$backup" "$desktop_path" 2>/dev/null; then
+		printf $" ✔ Restored \"%s\" -> %s\n" "$arg" "$desktop_path"
+		if command -v update-desktop-database >/dev/null 2>&1; then
+			update-desktop-database "$(dirname "$desktop_path")" >/dev/null 2>&1 \
+				|| $SUDOCMD update-desktop-database "$(dirname "$desktop_path")" >/dev/null 2>&1
+		fi
+	else
+		printf $" 💀 ERROR: failed to write %s\n" "$desktop_path"
+		return 1
+	fi
+}
+
+################################################################################################################################################################
 #				LOCK/UNLOCK
 ################################################################################################################################################################
 
@@ -602,6 +642,19 @@ case "$1" in
 		for arg in $entries; do
 			echo "$DIVIDING_LINE"
 			_launcher "${@}"
+		done
+		echo "$DIVIDING_LINE"
+		;;
+
+	'restore-desktop'|'--restore-desktop')
+		# Restore the .desktop file from the snapshot saved at install time
+		_determine_args
+		entries="$(echo "$@" | cut -f2- -d ' ')"
+		for arg in $entries; do
+			echo "$DIVIDING_LINE"
+			_determine_argpath
+			[ -n "$argpath" ] && _restore_desktop "${@}"
+			shift
 		done
 		echo "$DIVIDING_LINE"
 		;;


### PR DESCRIPTION
Closes: #2253

When a user (or the app itself) modifies an installed app's .desktop launcher — for example by appending a custom Name= to distinguish two parallel installs — there was no way to roll the change back short of reinstalling. Add a snapshot-and-restore flow:

* modules/install.am: in _post_installation_processes, after the local Exec= patching block, snapshot the live .desktop to $APPDIR/.am-installer/$arg-AM.desktop.orig. Capturing it AFTER the install script's post-processing (e.g. google-chrome's StartupWMClass fix) means restore brings back what AM intended, not the raw upstream .desktop from inside the AppImage.

* APP-MANAGER: route `restore-desktop` and `--restore-desktop` to management.am; add both forms to the completion list.

* modules/management.am: add _restore_desktop() and a matching case branch. The live .desktop path is read from the app's `remove` script (it always contains an absolute path matching "*AM.desktop"), matching the technique sketched in the issue thread. Attempts an unprivileged copy first, falls back to $SUDOCMD for system-wide installs, then refreshes the desktop database if available. Clear errors for: not a managed install, no snapshot (points the user at -i to reinstall), or unknown .desktop path.

* docs/guides-and-tutorials/launcher.md: new section documenting the option, including the post-install-patch caveat and the migration note for apps installed before this feature existed.

Tested in a clean debian:stable-slim container: real-flow restore via `am --restore-desktop test-app` rolls back user edits to the snapshot; the snapshot-missing error path fires correctly through the dispatcher for fixtures simulating pre-feature installs.