### PR TITLE
am2pla-site: place search bar on every list page, fix apps.json count

### DIFF
--- a/tools/am2pla-site
+++ b/tools/am2pla-site
@@ -42,8 +42,16 @@ CATEGORIES="am-utils android audio \
 ##########################################################
 
 function _update_json() {
+	# Exclude "items" (webapps and metapackages) from apps.json so the home
+	# search shows the same "X apps in the database" count that the stats
+	# line at the top of index.md reports (APPS_NUMBER, not APPS_NUMBER +
+	# ITEMS_NUMBER). The exclusion pattern mirrors the one used when
+	# computing APPS_NUMBER itself.
 	echo "[" > apps.json
 	for arg in $ARGS; do
+		case "$arg" in
+			ffwa-*|kdegames|kdeutils|node|platform-tools) continue;;
+		esac
 		description=$(grep "◆ $arg :" "$arch"-apps | sed 's/"/\\"/g; s/^.*: //')
 		printf "  {\n    \"packageName\": \"%b\",\n    \"description\": \"%b..\",\n    \"icon\": \"https://portable-linux-apps.github.io/icons/%b.png\"\n  },\n" "$arg" "$description" "$arg" >> apps.json
 	done
@@ -162,7 +170,7 @@ function _footer_categories() {
 ###############################
 
 ADD_SEARCH_BAR() {
-cat >> ./apps << EOF
+cat >> "$1" << EOF
 
 <div id="app-search-box" style="margin: 1em 0;">
   <label for="app-search-input" style="font-weight: bold;">Search applications:</label>
@@ -180,7 +188,7 @@ function _applications_list_header {
 	and [AppMan](https://github.com/ivan-hc/AppMan) for the x86_64 architecture, plus **$ITEMS_NUMBER** more entries and items to help you install apps more easily." >> apps.md
 	echo "" >> apps.md
 	echo "*Use your browser's built-in search tool to easily navigate to this page or use the tags below.*" >> apps.md
-	ADD_SEARCH_BAR
+	ADD_SEARCH_BAR apps.md
 	_categories_buttons >> apps.md
 	_table_head >> apps.md
 }
@@ -223,7 +231,7 @@ function _appimages_list_header {
 	and [AppMan](https://github.com/ivan-hc/AppMan) for the x86_64 architecture." >> appimages.md
 	echo "" >> appimages.md
 	echo "*Use your browser's built-in search tool to easily navigate to this page or use the tags below.*" >> appimages.md
-	echo "" >> appimages.md
+	ADD_SEARCH_BAR appimages.md
 	_back_to_apps_button >> appimages.md
 	_categories_buttons >> appimages.md
 	_table_head >> appimages.md
@@ -644,7 +652,7 @@ function _category_list_header {
 	and [AppMan](https://github.com/ivan-hc/AppMan) for the x86_64 architecture." >> "$category".md
 	echo "" >> "$category".md
 	echo "*Use your browser's built-in search tool to easily navigate to this page or use the tags below.*" >> "$category".md
-	echo "" >> "$category".md
+	ADD_SEARCH_BAR "$category".md
 	_back_to_apps_button >> "$category".md
 	_categories_buttons >> "$category".md
 	_table_head >> "$category".md


### PR DESCRIPTION
## Summary

Three related fixes in `tools/am2pla-site` reported by @ivan-hc and discovered while spot-checking the live site:

1. **`ADD_SEARCH_BAR` wrote to the wrong file** — `cat >> ./apps` left the search-bar HTML in an orphan `./apps` flat file instead of `apps.md`, so the search bar never appeared on `https://portable-linux-apps.github.io/apps.html`. Parameterised the function (`cat >> "$1"`) and updated the caller to pass `apps.md`.

2. **No search bar on category pages or `appimages.md`** — neither `_category_list_header` nor `_appimages_list_header` was calling `ADD_SEARCH_BAR`. Added the call to both, in the same position where `_applications_list_header` already had it.

3. **`apps.json` count included items** — `_update_json` iterated all of `$ARGS`, so the home page's "X apps in the database" status (rendered by `assets/js/search.js`) included `ffwa-*` webapps and the `kdegames` / `kdeutils` / `node` / `platform-tools` metapackages. Applied the same exclusion pattern that line 24 already uses for `APPS_NUMBER`, so `apps.json` and the stats line agree.

Live state before this PR:

```sh
$ curl -s https://portable-linux-apps.github.io/apps.html | grep -c 'app-search-input'
0
$ curl -s https://portable-linux-apps.github.io/android.html | grep -c 'app-search-input'
0
```

## Test plan

- [x] Ran the patched script against a fresh worktree of Portable-Linux-Apps.github.io@main locally. Verified:
  - `apps.md`, `appimages.md`, and every category .md file now contain `<div id="app-search-box">` and the search input.
  - `apps.json` no longer contains entries for `ffwa-*`, `kdegames`, `kdeutils`, `node`, `platform-tools`.
  - No orphan `./apps` file is created next to `./apps.md`.
- [ ] After merge, next hourly workflow run produces the same on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)