### PR TITLE
am2pla-site: emit categories list as a CSS grid of pill-links

### DIFF
--- a/tools/am2pla-site
+++ b/tools/am2pla-site
@@ -84,7 +84,19 @@ function _table_head() {
 }
 
 function _categories_buttons() {
-	printf "\n#### *Categories:* ***[AppImages](appimages.md)***%b\n\n" "$(for c in $CATEGORIES; do printf " - ***[$c]($c.md)***"; done)"
+	# Raw HTML grid; styles live in assets/css/style.scss on the website
+	# repo (.cat-grid / .cat-pill / .cat-pill--all). AppImages is the
+	# first cell with a "stand-out" modifier; the rest follow the
+	# CATEGORIES list (already alphabetical).
+	{
+		printf '\n#### *Categories*\n\n'
+		printf '<div class="cat-grid">\n'
+		printf '  <a class="cat-pill cat-pill--all" href="appimages.html">AppImages</a>\n'
+		for c in $CATEGORIES; do
+			printf '  <a class="cat-pill" href="%s.html">%s</a>\n' "$c" "$c"
+		done
+		printf '</div>\n\n'
+	}
 }
 
 function _back_to_home_or_apps_buttons() {


### PR DESCRIPTION
_categories_buttons() previously emitted a single line of bold-italic markdown links separated by " - ". On a wide page that's a long wrapping run; on a narrow viewport it's worse. Switch to raw HTML:

  <div class="cat-grid">
    <a class="cat-pill cat-pill--all" href="appimages.html">AppImages</a>
    <a class="cat-pill" href="am-utils.html">am-utils</a>
    ...
  </div>

CSS lives in Portable-Linux-Apps.github.io's assets/css/style.scss (.cat-grid uses grid-template-columns: repeat(auto-fit, ...) for responsive reflow; .cat-pill--all gives AppImages an accent background and bold weight so it stands out). Light/dark variants mirror the existing theme switch in that file.

Order is alphabetical (AppImages first as the meta-category, then the CATEGORIES list which is already alphabetical). Applies in every place that calls _categories_buttons: index.md, apps.md, appimages.md, and each category page.

## Desktop

<img width="1345" height="577" alt="image" src="https://github.com/user-attachments/assets/a8844a70-f85f-4e2d-b8c6-c47626f588c6" />

## Mobile

<img width="695" height="649" alt="image" src="https://github.com/user-attachments/assets/23c4dc4a-4ee0-4961-8b67-a9f5abe8cf01" />
