### PR TITLE
am2pla-site: emit bullets between category pills

### DIFF
--- a/tools/am2pla-site
+++ b/tools/am2pla-site
@@ -85,14 +85,17 @@ function _table_head() {
 
 function _categories_buttons() {
 	# Raw HTML grid; styles live in assets/css/style.scss on the website
-	# repo (.cat-grid / .cat-pill / .cat-pill--all). AppImages is the
-	# first cell with a "stand-out" modifier; the rest follow the
-	# CATEGORIES list (already alphabetical).
+	# repo (.cat-grid / .cat-pill / .cat-pill--all / .cat-sep). AppImages
+	# is the first cell with a "stand-out" modifier; the rest follow the
+	# CATEGORIES list (already alphabetical). A .cat-sep bullet is emitted
+	# between pills so the CSS can use a flex container with a small gap
+	# and still get a clear visual separator between links.
 	{
 		printf '\n#### *Categories*\n\n'
 		printf '<div class="cat-grid">\n'
 		printf '  <a class="cat-pill cat-pill--all" href="appimages.html">AppImages</a>\n'
 		for c in $CATEGORIES; do
+			printf '  <span class="cat-sep" aria-hidden="true">\xe2\x80\xa2</span>\n'
 			printf '  <a class="cat-pill" href="%s.html">%s</a>\n' "$c" "$c"
 		done
 		printf '</div>\n\n'


### PR DESCRIPTION
Per maintainer feedback (and andy's review of the live preview), the grid layout between the page heading and the apps table still felt loose — pills were single-line and short, but the empty horizontal space inside each grid cell padded them apart visually.

Pair with a website-side CSS change that switches the container from a CSS Grid (with uniform cells) to a flex layout (pills pack tight to their content width, gap controls spacing). Bullets emitted as .cat-sep spans between pills give a clear visual separator at that tighter spacing.

The HTML emitted for a category page now looks like:

  <div class="cat-grid">
    <a class="cat-pill cat-pill--all" href="appimages.html">AppImages</a>
    <span class="cat-sep" aria-hidden="true">•</span>
    <a class="cat-pill" href="am-utils.html">am-utils</a>
    <span class="cat-sep" aria-hidden="true">•</span>
    ...
  </div>

aria-hidden so screen readers don't announce the bullet between every link in the nav.